### PR TITLE
Add sticky mode (sticky/action/cancel keys)

### DIFF
--- a/changelog/3.3.0.md
+++ b/changelog/3.3.0.md
@@ -11,3 +11,10 @@
     the hint overlay by the `::backdrop` style of the host page
   - Or press "Restore Default Style" in option page
 - Add more clickable selectors for ARIA awared elements
+- Add Sticky Mode as an alternative to holding the Magic Key
+  - Press the Sticky Key to show hints that stay visible without holding a key
+  - Press the Action Key to run the action, or the Cancel Key to dismiss
+  - The Action Key and Cancel Key also work during a Magic Key hold session
+  - Configure the new keys in the option page (all disabled by default)
+- Make the Magic Key optional (press "Disable" in the option page to turn it off)
+- Validate key configuration conflicts in the option page

--- a/changelog/3.3.0.md
+++ b/changelog/3.3.0.md
@@ -16,5 +16,5 @@
   - Press the Action Key to run the action, or the Cancel Key to dismiss
   - The Action Key and Cancel Key also work during a Magic Key hold session
   - Configure the new keys in the option page (all disabled by default)
-- Make the Magic Key optional (press "Disable" in the option page to turn it off)
+- Make the Magic Key optional (press "Unbind" in the option page to turn it off)
 - Validate key configuration conflicts in the option page

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -18,7 +18,14 @@ const rectAggregator = new RectAggregator();
 const blurer = new Blurer();
 
 async function setup() {
-  const setting = await settingsClient.get(["magicKey", "blurKey", "hints"]);
+  const setting = await settingsClient.get([
+    "magicKey",
+    "blurKey",
+    "hints",
+    "stickyKey",
+    "actionKey",
+    "cancelKey",
+  ]);
   await keyboardHandler.setup(setting);
   console.debug("settings loaded");
 }

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -10,20 +10,43 @@ import { printError } from "../lib/errors.ts";
 export class KeyboardHandlerContentAll {
   private hitMatcher: KeyHoldMatcher | null = null;
   private blurMatcher: KeyHoldMatcher | null = null;
+  private stickyMatcher: KeyHoldMatcher | null = null;
+  private actionMatcher: KeyHoldMatcher | null = null;
+  private cancelMatcher: KeyHoldMatcher | null = null;
   private hintLetters = "";
   private matchedBlacklist: string[] = [];
+  // true when hints were attached by magic key hold (fires on keyup);
+  // false when attached by sticky key (fires only via actionKey/cancelKey).
+  private holdHinting = false;
 
   constructor(
     private readonly blurer: Blurer,
     private readonly hinter: Hinter,
   ) {}
 
-  async setup(settings: Pick<Settings, "magicKey" | "blurKey" | "hints">) {
+  async setup(
+    settings: Pick<
+      Settings,
+      "magicKey" | "blurKey" | "hints" | "stickyKey" | "actionKey" | "cancelKey"
+    >,
+  ) {
     this.hintLetters = settings.hints;
     this.hitMatcher =
       settings.magicKey === "" ? null : KeyHoldMatcher.parse(settings.magicKey);
     this.blurMatcher =
       settings.blurKey === "" ? null : KeyHoldMatcher.parse(settings.blurKey);
+    this.stickyMatcher =
+      settings.stickyKey === ""
+        ? null
+        : KeyHoldMatcher.parse(settings.stickyKey);
+    this.actionMatcher =
+      settings.actionKey === ""
+        ? null
+        : KeyHoldMatcher.parse(settings.actionKey);
+    this.cancelMatcher =
+      settings.cancelKey === ""
+        ? null
+        : KeyHoldMatcher.parse(settings.cancelKey);
     this.matchedBlacklist = await settingsClient.matchBlacklist(location.href);
   }
 
@@ -31,12 +54,31 @@ export class KeyboardHandlerContentAll {
   handleKeydown(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keydown(event);
     const blurMatcher = this.blurMatcher?.keydown(event);
+    const stickyMatcher = this.stickyMatcher?.keydown(event);
+    const actionMatcher = this.actionMatcher?.keydown(event);
+    const cancelMatcher = this.cancelMatcher?.keydown(event);
 
     if (this.isBlacklisted()) {
       return false;
     }
 
     if (this.hinter.isHinting) {
+      if (cancelMatcher?.match()) {
+        const { shiftKey, altKey, ctrlKey, metaKey } = event;
+        this.hinter
+          .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, false)
+          .catch(printError);
+        this.holdHinting = false;
+        return true;
+      }
+      if (actionMatcher?.match()) {
+        const { shiftKey, altKey, ctrlKey, metaKey } = event;
+        this.hinter
+          .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, true)
+          .catch(printError);
+        this.holdHinting = false;
+        return true;
+      }
       if (isSingleLetter(event.key) && this.hintLetters.includes(event.key)) {
         this.hinter.hitHint(event.key).catch(printError);
         return true;
@@ -47,6 +89,12 @@ export class KeyboardHandlerContentAll {
     } else {
       if (!isEditing() && hitMatcher?.match()) {
         this.hinter.attachHints().catch(printError);
+        this.holdHinting = true;
+        return true;
+      }
+      if (!isEditing() && stickyMatcher?.match()) {
+        this.hinter.attachHints().catch(printError);
+        this.holdHinting = false;
         return true;
       }
       if (blurMatcher?.match()) {
@@ -60,16 +108,20 @@ export class KeyboardHandlerContentAll {
   handleKeyup(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keyup(event);
     this.blurMatcher?.keyup(event);
+    this.stickyMatcher?.keyup(event);
+    this.actionMatcher?.keyup(event);
+    this.cancelMatcher?.keyup(event);
 
     if (this.isBlacklisted()) {
       return false;
     }
 
-    if (this.hinter.isHinting && !hitMatcher?.match()) {
+    if (this.hinter.isHinting && this.holdHinting && !hitMatcher?.match()) {
       const { shiftKey, altKey, ctrlKey, metaKey } = event;
       this.hinter
         .removeHints({ shiftKey, altKey, ctrlKey, metaKey })
         .catch(printError);
+      this.holdHinting = false;
       return true;
     }
     return false;

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -50,6 +50,15 @@ export class KeyboardHandlerContentAll {
     this.matchedBlacklist = await settingsClient.matchBlacklist(location.href);
   }
 
+  // Reset the held-key history of every matcher.
+  private resetMatchers() {
+    this.hitMatcher?.reset();
+    this.blurMatcher?.reset();
+    this.stickyMatcher?.reset();
+    this.actionMatcher?.reset();
+    this.cancelMatcher?.reset();
+  }
+
   // Return true if the event is handled.
   handleKeydown(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keydown(event);
@@ -68,7 +77,7 @@ export class KeyboardHandlerContentAll {
         this.hinter
           .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, false)
           .catch(printError);
-        this.holdHinting = false;
+        this.endSession();
         return true;
       }
       if (actionMatcher?.match()) {
@@ -76,7 +85,7 @@ export class KeyboardHandlerContentAll {
         this.hinter
           .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, true)
           .catch(printError);
-        this.holdHinting = false;
+        this.endSession();
         return true;
       }
       if (isSingleLetter(event.key) && this.hintLetters.includes(event.key)) {
@@ -121,10 +130,20 @@ export class KeyboardHandlerContentAll {
       this.hinter
         .removeHints({ shiftKey, altKey, ctrlKey, metaKey })
         .catch(printError);
-      this.holdHinting = false;
+      this.endSession();
       return true;
     }
     return false;
+  }
+
+  // End the current hint session. Resetting the matchers clears any key left
+  // "held" in their history because its keyup was lost — e.g. an Action Key
+  // that fired a target=_blank action and opened a new tab, stealing focus
+  // before keyup arrived. Without this, the stuck key would spuriously match on
+  // the next session.
+  private endSession() {
+    this.holdHinting = false;
+    this.resetMatchers();
   }
 
   // Just hijack the event when hinting.

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -128,7 +128,7 @@ export class KeyboardHandlerContentAll {
     if (this.hinter.isHinting && this.holdHinting && !hitMatcher?.match()) {
       const { shiftKey, altKey, ctrlKey, metaKey } = event;
       this.hinter
-        .removeHints({ shiftKey, altKey, ctrlKey, metaKey })
+        .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, true)
         .catch(printError);
       this.endSession();
       return true;

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -39,7 +39,9 @@ chrome.runtime.onMessage.addListener(
     )
     .add("AttachHints", () => hinter.attachHints())
     .add("HitHint", ({ key }) => hinter.hitHint(key))
-    .add("RemoveHints", ({ options }) => hinter.removeHints(options))
+    .add("RemoveHints", ({ options, execute }) =>
+      hinter.removeHints(options, execute),
+    )
     .buildListener(),
 );
 

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -115,12 +115,16 @@ export class HinterContentRoot {
     if (!context) {
       throw Error("Ilegal state invocation: hinting not started");
     }
+    // Clear the context synchronously, before any await. Executing the action
+    // round-trips a message (e.g. a target=_blank action opening a new tab); a
+    // second AttachHints arriving meanwhile must not see a stale context and
+    // throw "already started hinting".
+    this.context = null;
     this.view.remove();
     await this.rectAggregator.action(
       execute ? context.hitTarget?.id : undefined,
       options,
     );
-    this.context = null;
   }
 }
 

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -110,13 +110,16 @@ export class HinterContentRoot {
     this.view.hit(changes, actionDescriptions);
   }
 
-  async removeHints(options: ActionOptions) {
+  async removeHints(options: ActionOptions, execute = true) {
     const context = this.context;
     if (!context) {
       throw Error("Ilegal state invocation: hinting not started");
     }
     this.view.remove();
-    await this.rectAggregator.action(context.hitTarget?.id, options);
+    await this.rectAggregator.action(
+      execute ? context.hitTarget?.id : undefined,
+      options,
+    );
     this.context = null;
   }
 }

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -110,7 +110,7 @@ export class HinterContentRoot {
     this.view.hit(changes, actionDescriptions);
   }
 
-  async removeHints(options: ActionOptions, execute = true) {
+  async removeHints(options: ActionOptions, execute: boolean) {
     const context = this.context;
     if (!context) {
       throw Error("Ilegal state invocation: hinting not started");

--- a/src/content-root/rect-aggregator-client.ts
+++ b/src/content-root/rect-aggregator-client.ts
@@ -37,7 +37,6 @@ export class RectAggregatorClient {
     this.callback = (rects) => enqueue.next(rects);
     for await (const rects of dequeue) {
       if (rects === "Complete") {
-        this.callback = null;
         return;
       } else if (rects) {
         yield rects;
@@ -63,7 +62,12 @@ export class RectAggregatorClient {
     options: ActionOptions,
   ) {
     if (!this.callback) throw Error("Illegal state: not aggregating");
-    this.callback("Complete");
+    // Clear the callback synchronously before signalling "Complete" (which ends
+    // the aggregate() loop on a later micro-task) so a second aggregate() call
+    // from a concurrent AttachHints does not throw "already fetching".
+    const callback = this.callback;
+    this.callback = null;
+    callback("Complete");
     if (elementId)
       return sendToRuntime("ExecuteAction", { id: elementId, options });
   }

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -26,7 +26,7 @@ interface Messages {
     response: void;
   };
   RemoveHints: {
-    payload: { options: ActionOptions };
+    payload: { options: ActionOptions; execute: boolean };
     response: void;
   };
   GetFrameId: {

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -23,7 +23,7 @@ export default class HinterClient {
     await sendToRuntime("HitHint", { key });
   }
 
-  async removeHints(options: ActionOptions, execute = true) {
+  async removeHints(options: ActionOptions, execute: boolean) {
     if (!this.hinting) throw Error("Illegal state");
     this.hinting = false;
     await sendToRuntime("RemoveHints", { options, execute });

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -23,9 +23,9 @@ export default class HinterClient {
     await sendToRuntime("HitHint", { key });
   }
 
-  async removeHints(options: ActionOptions) {
+  async removeHints(options: ActionOptions, execute = true) {
     if (!this.hinting) throw Error("Illegal state");
     this.hinting = false;
-    await sendToRuntime("RemoveHints", { options });
+    await sendToRuntime("RemoveHints", { options, execute });
   }
 }

--- a/src/lib/key-chars.ts
+++ b/src/lib/key-chars.ts
@@ -1,0 +1,56 @@
+// Maps a KeyboardEvent.code of a "writing system" key to the character(s) it
+// can produce *without modifiers*. The same physical `code` yields different
+// characters between layouts (US ANSI vs Japanese JIS), so each candidate is
+// listed and conflict detection over-approximates: a hint set containing ANY
+// candidate is treated as a conflict.
+//
+// Hint matching at runtime compares `event.key` (the produced character)
+// against the configured hint letters, while key bindings are stored as
+// `event.code`. This map bridges those two representations.
+
+// US ANSI unshifted characters for punctuation/space codes.
+const US_CHARS: Record<string, string> = {
+  Backquote: "`",
+  Minus: "-",
+  Equal: "=",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  Space: " ",
+  NumpadDivide: "/",
+  NumpadMultiply: "*",
+  NumpadSubtract: "-",
+  NumpadAdd: "+",
+  NumpadDecimal: ".",
+};
+
+// Japanese JIS unshifted characters where they differ from US ANSI.
+const JIS_CHARS: Record<string, string> = {
+  Equal: "^",
+  BracketLeft: "@",
+  BracketRight: "[",
+  Backslash: "]",
+  Quote: ":",
+  IntlYen: "¥", // ¥
+  IntlRo: "\\",
+};
+
+export function keyCodeToChars(code: string): string[] {
+  const chars = new Set<string>();
+
+  const letter = /^Key([A-Za-z])$/.exec(code);
+  if (letter) chars.add(letter[1].toLowerCase());
+
+  const digit = /^(?:Digit|Numpad)([0-9])$/.exec(code);
+  if (digit) chars.add(digit[1]);
+
+  if (code in US_CHARS) chars.add(US_CHARS[code]);
+  if (code in JIS_CHARS) chars.add(JIS_CHARS[code]);
+
+  return [...chars];
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -24,6 +24,9 @@ const DEFAULT_SETTINGS: Settings = {
   magicKey: "Space",
   hints: "asdfghjkl",
   blurKey: "",
+  stickyKey: "",
+  actionKey: "",
+  cancelKey: "",
   css: "", // load from an external file
   blackList: DEFAULT_BLACK_LIST,
   additionalSelectors: DEFAULT_ADDITIONAL_SELECTORS,

--- a/src/options.css
+++ b/src/options.css
@@ -1,5 +1,7 @@
 body {
   font-size: 100%;
+  max-width: 800px;
+  margin: 0 auto;
 }
 h1 > img {
   width: 1em;
@@ -33,6 +35,7 @@ input[is^="key"] {
 }
 details {
   margin: 9px 6px;
+  padding: 6px;
   background-color: #eee;
 }
 summary {
@@ -42,9 +45,8 @@ summary {
 
 textarea {
   resize: both;
-  width: 500px;
+  width: 100%;
   height: 20em;
-  font-size: 14px;
   font-family:
     Consolas,
     Menlo,

--- a/src/options.css
+++ b/src/options.css
@@ -7,6 +7,21 @@ h1 > img {
 .config-table th {
   text-align: right;
 }
+
+/* key configuration conflicts */
+#key-conflicts {
+  background-color: #fcc;
+  color: #900;
+  border: solid #c00 1px;
+  padding: 8px 12px;
+  margin: 8px 0;
+}
+#key-conflicts ul {
+  margin: 4px 0 0;
+}
+.config-table input:invalid {
+  outline: solid #c00 2px;
+}
 input {
   border: solid gray 1px;
   padding: 2px;

--- a/src/options.css
+++ b/src/options.css
@@ -7,8 +7,6 @@ h1 > img {
 .config-table th {
   text-align: right;
 }
-
-/* key configuration conflicts */
 #key-conflicts {
   background-color: #fcc;
   color: #900;
@@ -42,7 +40,6 @@ summary {
   cursor: pointer;
 }
 
-/* textarea or similar elements */
 textarea {
   resize: both;
   width: 500px;
@@ -61,7 +58,6 @@ textarea {
     sans-serif;
 }
 
-/* storage usage */
 #total-storage-usage {
   position: fixed;
   top: 0px;

--- a/src/options.html
+++ b/src/options.html
@@ -22,7 +22,7 @@
       <div id="key-conflicts" role="alert" hidden></div>
       <h2>Basic Settings</h2>
       <p>
-        The Magic Key is optional. Press [Disable] to disable it if you prefer
+        The Magic Key is optional. Press [Disable] to turn it off if you prefer
         to use Sticky Mode (below) instead.
       </p>
       <table class="config-table">
@@ -40,8 +40,8 @@
             <button
               data-valueset-target="#magic-key"
               data-valueset=""
-              alt="Disable magic key"
-              title="Disable magic key"
+              alt="Disable the Magic Key"
+              title="Disable the Magic Key"
             >
               Disable
             </button>
@@ -53,10 +53,10 @@
         </tr>
       </table>
 
-      <h2>Blur key</h2>
+      <h2>Blur Key</h2>
       <p>
-        A support function to in-activate a current focused element such as
-        input, textarea and iframe. Press [Clear] if you want to disable.
+        A helper that deactivates the currently focused element, such as an
+        input, textarea, or iframe. Press [Clear] to disable it.
       </p>
       <table class="config-table">
         <tr>
@@ -83,10 +83,11 @@
 
       <h2>Sticky Mode</h2>
       <p>
-        An alternative to the Magic Key hold: press Sticky Key to keep hints
-        visible without holding a key, then press Action Key to fire the action
-        or Cancel Key to dismiss. Press [Clear] on each field to disable. Action
-        Key and Cancel Key also work for Magic Key sessions.
+        An alternative to holding down the Magic Key: press the Sticky Key to
+        show the hints and keep them visible without holding a key down, then
+        press the Action Key to run the action or the Cancel Key to dismiss
+        them. Press [Clear] on a field to disable it. The Action Key and Cancel
+        Key also work during Magic Key sessions.
       </p>
       <table class="config-table">
         <tr>
@@ -153,7 +154,7 @@
 
       <h2>Style</h2>
 
-      <p>Styles for Hint elements and overlays.</p>
+      <p>Styles for the hint elements and overlays.</p>
 
       <textarea id="css" name="css" data-lang="css"></textarea>
       <div><knavi-storage-usage name="css"></knavi-storage-usage></div>
@@ -164,10 +165,10 @@
       <h2>Black List</h2>
 
       <p>
-        Stop knavi on listed pages. You can use some wildcard pattern matching.
-        See
+        Disable knavi on the listed pages. You can use wildcard pattern
+        matching. See
         <a href="https://github.com/rbranson/glob-trie.js#expression-support"
-          >glob-trie.js docs</a
+          >the glob-trie.js docs</a
         >.
       </p>
 
@@ -180,11 +181,12 @@
       <h2>Additional Selectors</h2>
 
       <p>
-        Additional hintable element selectors in the specific pages. A JSON key
-        is an URL pattern used in wildcard matching (<a
+        Extra selectors for hintable elements on specific pages. Each key is a
+        URL pattern matched with wildcards (<a
           href="https://github.com/rbranson/glob-trie.js#expression-support"
           >glob-trie.js</a
-        >). A JSON value is CSS selector or array. This JSON is serialized as
+        >), and each value is a CSS selector or an array of selectors. The
+        config is parsed as
         <a href="https://github.com/json5/json5#example">JSON5</a>.
       </p>
       <textarea
@@ -206,8 +208,8 @@
 
         <h2>Settings Storage</h2>
         <p>
-          Indicate where these setting values are stored.
-          <code>sync</code> shares your settings between your browser.
+          Choose where these settings are stored. <code>sync</code> shares your
+          settings across your browsers.
         </p>
         <table class="config-table">
           <tr>

--- a/src/options.html
+++ b/src/options.html
@@ -21,8 +21,8 @@
     <storage-form storage-area="chrome-sync">
       <h2>Basic Settings</h2>
       <p>
-        The Magic Key is optional. Press [Clear] to disable it if you prefer to
-        use Sticky Mode (below) instead.
+        The Magic Key is optional. Press [Disable] to disable it if you prefer
+        to use Sticky Mode (below) instead.
       </p>
       <table class="config-table">
         <tr>
@@ -42,6 +42,14 @@
               title="Clear to disable"
             >
               Clear
+            </button>
+            <button
+              data-valueset-target="#magic-key"
+              data-valueset=""
+              alt="Disable magic key"
+              title="Disable magic key"
+            >
+              Disable
             </button>
           </td>
         </tr>

--- a/src/options.html
+++ b/src/options.html
@@ -67,6 +67,76 @@
         </tr>
       </table>
 
+      <h2>Sticky Mode</h2>
+      <p>
+        An alternative to the Magic Key hold: press Sticky Key to keep hints
+        visible without holding a key, then press Action Key to fire the action
+        or Cancel Key to dismiss. Press [Clear] on each field to disable. Action
+        Key and Cancel Key also work for Magic Key sessions.
+      </p>
+      <table class="config-table">
+        <tr>
+          <th><label for="sticky-key">Sticky Key</label></th>
+          <td>
+            <input
+              is="key-input"
+              id="sticky-key"
+              name="stickyKey"
+              value=""
+              autocomplete="off"
+            />
+            <button
+              type="button"
+              data-clear-target="#sticky-key"
+              alt="Clear to disable"
+              title="Clear to disable"
+            >
+              Clear
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <th><label for="action-key">Action Key</label></th>
+          <td>
+            <input
+              is="key-input"
+              id="action-key"
+              name="actionKey"
+              value=""
+              autocomplete="off"
+            />
+            <button
+              type="button"
+              data-clear-target="#action-key"
+              alt="Clear to disable"
+              title="Clear to disable"
+            >
+              Clear
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <th><label for="cancel-key">Cancel Key</label></th>
+          <td>
+            <input
+              is="key-input"
+              id="cancel-key"
+              name="cancelKey"
+              value=""
+              autocomplete="off"
+            />
+            <button
+              type="button"
+              data-clear-target="#cancel-key"
+              alt="Clear to disable"
+              title="Clear to disable"
+            >
+              Clear
+            </button>
+          </td>
+        </tr>
+      </table>
+
       <h2>Style</h2>
 
       <p>Styles for Hint elements and overlays.</p>

--- a/src/options.html
+++ b/src/options.html
@@ -27,7 +27,7 @@
         The Hint Letters are the characters used to label the hints.
       </p>
       <p>
-        The Magic Key is optional. Press [Disable] to turn it off if you prefer
+        The Magic Key is optional. Press [Unbind] to turn it off if you prefer
         to use Sticky Mode (below) instead.
       </p>
       <table class="config-table">
@@ -41,14 +41,18 @@
               value="Space"
               autocomplete="off"
             />
-            <button data-clear-target="#magic-key">Reset</button>
+            <button
+              data-clear-target="#magic-key"
+              title="Reset to the default key"
+            >
+              Reset
+            </button>
             <button
               data-valueset-target="#magic-key"
               data-valueset=""
-              alt="Disable the Magic Key"
-              title="Disable the Magic Key"
+              title="Unbind to disable"
             >
-              Disable
+              Unbind
             </button>
           </td>
         </tr>
@@ -61,7 +65,7 @@
       <h2>Blur Key</h2>
       <p>
         A helper that deactivates the currently focused element, such as an
-        input, textarea, or iframe. Press [Clear] to disable it.
+        input, textarea, or iframe. Press [Unbind] to disable it.
       </p>
       <table class="config-table">
         <tr>
@@ -75,12 +79,11 @@
               autocomplete="off"
             />
             <button
-              type="button"
-              data-clear-target="#blur-key"
-              alt="Clear to disable"
-              title="Clear to disable"
+              data-valueset-target="#blur-key"
+              data-valueset=""
+              title="Unbind to disable"
             >
-              Clear
+              Unbind
             </button>
           </td>
         </tr>
@@ -91,7 +94,7 @@
         An alternative to holding down the Magic Key: press the Sticky Key to
         show the hints and keep them visible without holding a key down, then
         press the Action Key to run the action or the Cancel Key to dismiss
-        them. Press [Clear] on a field to disable it. The Action Key and Cancel
+        them. Press [Unbind] on a field to disable it. The Action Key and Cancel
         Key also work during Magic Key sessions.
       </p>
       <table class="config-table">
@@ -106,12 +109,11 @@
               autocomplete="off"
             />
             <button
-              type="button"
-              data-clear-target="#sticky-key"
-              alt="Clear to disable"
-              title="Clear to disable"
+              data-valueset-target="#sticky-key"
+              data-valueset=""
+              title="Unbind to disable"
             >
-              Clear
+              Unbind
             </button>
           </td>
         </tr>
@@ -126,12 +128,11 @@
               autocomplete="off"
             />
             <button
-              type="button"
-              data-clear-target="#action-key"
-              alt="Clear to disable"
-              title="Clear to disable"
+              data-valueset-target="#action-key"
+              data-valueset=""
+              title="Unbind to disable"
             >
-              Clear
+              Unbind
             </button>
           </td>
         </tr>
@@ -146,12 +147,11 @@
               autocomplete="off"
             />
             <button
-              type="button"
-              data-clear-target="#cancel-key"
-              alt="Clear to disable"
-              title="Clear to disable"
+              data-valueset-target="#cancel-key"
+              data-valueset=""
+              title="Unbind to disable"
             >
-              Clear
+              Unbind
             </button>
           </td>
         </tr>

--- a/src/options.html
+++ b/src/options.html
@@ -42,7 +42,8 @@
               autocomplete="off"
             />
             <button
-              data-clear-target="#magic-key"
+              data-valueset-target="#magic-key"
+              data-valueset-default
               title="Reset to the default key"
             >
               Reset

--- a/src/options.html
+++ b/src/options.html
@@ -19,6 +19,7 @@
     <h1><img src="icon48.png" title="Icon" /> KNavi Settings</h1>
 
     <storage-form storage-area="chrome-sync">
+      <div id="key-conflicts" role="alert" hidden></div>
       <h2>Basic Settings</h2>
       <p>
         The Magic Key is optional. Press [Disable] to disable it if you prefer
@@ -35,14 +36,7 @@
               value="Space"
               autocomplete="off"
             />
-            <button
-              type="button"
-              data-clear-target="#magic-key"
-              alt="Clear to disable"
-              title="Clear to disable"
-            >
-              Clear
-            </button>
+            <button data-clear-target="#magic-key">Reset</button>
             <button
               data-valueset-target="#magic-key"
               data-valueset=""

--- a/src/options.html
+++ b/src/options.html
@@ -22,6 +22,11 @@
       <div id="key-conflicts" role="alert" hidden></div>
       <h2>Basic Settings</h2>
       <p>
+        Hold down the Magic Key to show the hints, type a hint's letters to
+        select its element, then release the Magic Key to run the action on it.
+        The Hint Letters are the characters used to label the hints.
+      </p>
+      <p>
         The Magic Key is optional. Press [Disable] to turn it off if you prefer
         to use Sticky Mode (below) instead.
       </p>

--- a/src/options.html
+++ b/src/options.html
@@ -20,6 +20,10 @@
 
     <storage-form storage-area="chrome-sync">
       <h2>Basic Settings</h2>
+      <p>
+        The Magic Key is optional. Press [Clear] to disable it if you prefer to
+        use Sticky Mode (below) instead.
+      </p>
       <table class="config-table">
         <tr>
           <th><label for="magic-key">Magic Key</label></th>
@@ -31,6 +35,14 @@
               value="Space"
               autocomplete="off"
             />
+            <button
+              type="button"
+              data-clear-target="#magic-key"
+              alt="Clear to disable"
+              title="Clear to disable"
+            >
+              Clear
+            </button>
           </td>
         </tr>
         <tr>

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,7 @@ async function init() {
 
   initClearButton(body);
   initRestoreButton(body);
+  initValuesetButton(body);
 }
 
 interface ValueContaienrElement extends HTMLElement {
@@ -72,6 +73,26 @@ function initClearButton(body: HTMLElement) {
         console.log("clear: ", target);
         (target as HTMLInputElement).value =
           (target as HTMLInputElement).defaultValue ?? "";
+        dispatchChangeEvent(target as HTMLElement);
+      }
+    });
+  }
+}
+
+// Sets the target input to a fixed value from `data-valueset`.
+// Unlike the clear button (which resets to the input's defaultValue), this can
+// force an empty value to disable a key such as the Magic Key.
+function initValuesetButton(body: HTMLElement) {
+  for (const element of body.querySelectorAll("[data-valueset-target]")) {
+    if (!(element instanceof HTMLElement)) continue;
+    console.log("valueset button: ", element);
+    element.addEventListener("click", () => {
+      const targetSelector = element.dataset.valuesetTarget;
+      if (!targetSelector) return;
+      const value = element.dataset.valueset ?? "";
+      for (const target of document.querySelectorAll(targetSelector)) {
+        console.log("valueset: ", target, value);
+        (target as HTMLInputElement).value = value;
         dispatchChangeEvent(target as HTMLElement);
       }
     });

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,7 +15,6 @@ async function init() {
   keyInput.register();
   registerKnaviStorageUsage();
 
-  initClearButton(body);
   initRestoreButton(body);
   initValuesetButton(body);
   initKeyConflictValidation(body);
@@ -187,49 +186,39 @@ function initRestoreButton(body: HTMLElement) {
   }
 }
 
-function initClearButton(body: HTMLElement) {
-  for (const element of body.querySelectorAll("[data-clear-target]")) {
-    if (!(element instanceof HTMLElement)) continue;
-    console.log("clear button: ", element);
-    element.addEventListener("click", () => {
-      const targetSelector = element.dataset.clearTarget;
-      if (!targetSelector) return;
-      for (const target of document.querySelectorAll(targetSelector)) {
-        console.log("clear: ", target);
-        (target as HTMLInputElement).value =
-          (target as HTMLInputElement).defaultValue ?? "";
-        dispatchChangeEvent(target as HTMLElement);
-      }
-    });
-  }
-}
-
-// Sets the target input to a fixed value from `data-valueset`.
-// Unlike the clear button (which resets to the input's defaultValue), this can
-// force an empty value to disable a key such as the Magic Key.
+// Sets the target input(s) selected by `data-valueset-target` to a value:
+//   - `data-valueset-default` (boolean): the input's default value, or
+//   - `data-valueset="<literal>"`: a fixed value (e.g. "" to disable a key).
+// The button is disabled while every target already holds that value, since
+// clicking it would be a no-op.
 function initValuesetButton(body: HTMLElement) {
   for (const element of body.querySelectorAll("[data-valueset-target]")) {
     if (!(element instanceof HTMLButtonElement)) continue;
     console.log("valueset button: ", element);
     const targetSelector = element.dataset.valuesetTarget;
     if (!targetSelector) continue;
-    const value = element.dataset.valueset ?? "";
+    const literal = element.dataset.valueset ?? "";
+    const valueFor = (target: HTMLInputElement) =>
+      element.hasAttribute("data-valueset-default")
+        ? target.defaultValue
+        : literal;
 
     element.addEventListener("click", () => {
-      for (const target of document.querySelectorAll(targetSelector)) {
-        console.log("valueset: ", target, value);
-        (target as HTMLInputElement).value = value;
-        dispatchChangeEvent(target as HTMLElement);
+      for (const target of document.querySelectorAll<HTMLInputElement>(
+        targetSelector,
+      )) {
+        console.log("valueset: ", target, valueFor(target));
+        target.value = valueFor(target);
+        dispatchChangeEvent(target);
       }
     });
 
-    // Disable the button while every target already holds the value (e.g. an
-    // already-unbound key), since clicking it would be a no-op.
     const syncDisabled = () => {
       const targets =
         document.querySelectorAll<HTMLInputElement>(targetSelector);
       element.disabled =
-        targets.length > 0 && [...targets].every((t) => t.value === value);
+        targets.length > 0 &&
+        [...targets].every((t) => t.value === valueFor(t));
     };
     body.addEventListener("input", syncDisabled);
     body.addEventListener("change", syncDisabled);

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,21 +31,28 @@ const KEY_LABELS: Record<string, string> = {
 };
 
 // Key-pattern pairs that must not be bound to the same key.
-// Sticky Key is intentionally allowed to share a key with Action/Cancel/hints
-// since it is released before the hinting input phase begins.
+//
+// Keys are split by the phase in which they fire:
+//   - while NOT hinting: Magic Key, Sticky Key, Blur Key
+//   - while hinting:     Action Key, Cancel Key, hint letters
+//     (the Magic Key is also held throughout a hold session, so it overlaps
+//      the hinting phase too)
+// Keys that only ever fire in different phases can safely share a binding.
+// Hence Blur Key may share with Action/Cancel/hints, and Sticky Key may share
+// with Action/Cancel/hints.
 const KEY_PAIR_CONFLICTS: [string, string][] = [
   ["magicKey", "stickyKey"],
   ["magicKey", "blurKey"],
   ["magicKey", "actionKey"],
   ["magicKey", "cancelKey"],
   ["stickyKey", "blurKey"],
-  ["blurKey", "actionKey"],
-  ["blurKey", "cancelKey"],
   ["actionKey", "cancelKey"],
 ];
 
-// Key patterns that must not coincide with a hint letter. (Sticky Key excluded.)
-const HINTS_VS_KEYS = ["magicKey", "blurKey", "actionKey", "cancelKey"];
+// Key patterns that must not coincide with a hint letter: only keys that fire
+// during the hinting phase. (Sticky Key and Blur Key fire only while not
+// hinting, so they are excluded.)
+const HINTS_VS_KEYS = ["magicKey", "actionKey", "cancelKey"];
 
 // Normalize a key-input pattern string (e.g. "Ctrl + KeyA") for comparison.
 function normalizeKeyPattern(value: string): string {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,7 @@
 import * as storageForm from "storage-form";
 import * as keyInput from "key-input-elements";
 import settings from "./lib/settings.ts";
+import { keyCodeToChars } from "./lib/key-chars.ts";
 import { waitUntil } from "./dom/animations.ts";
 import { printError } from "./lib/errors.ts";
 
@@ -17,6 +18,123 @@ async function init() {
   initClearButton(body);
   initRestoreButton(body);
   initValuesetButton(body);
+  initKeyConflictValidation(body);
+}
+
+const KEY_LABELS: Record<string, string> = {
+  magicKey: "Magic Key",
+  stickyKey: "Sticky Key",
+  blurKey: "Blur Key",
+  actionKey: "Action Key",
+  cancelKey: "Cancel Key",
+  hints: "Hint Letters",
+};
+
+// Key-pattern pairs that must not be bound to the same key.
+// Sticky Key is intentionally allowed to share a key with Action/Cancel/hints
+// since it is released before the hinting input phase begins.
+const KEY_PAIR_CONFLICTS: [string, string][] = [
+  ["magicKey", "stickyKey"],
+  ["magicKey", "blurKey"],
+  ["magicKey", "actionKey"],
+  ["magicKey", "cancelKey"],
+  ["stickyKey", "blurKey"],
+  ["blurKey", "actionKey"],
+  ["blurKey", "cancelKey"],
+  ["actionKey", "cancelKey"],
+];
+
+// Key patterns that must not coincide with a hint letter. (Sticky Key excluded.)
+const HINTS_VS_KEYS = ["magicKey", "blurKey", "actionKey", "cancelKey"];
+
+// Normalize a key-input pattern string (e.g. "Ctrl + KeyA") for comparison.
+function normalizeKeyPattern(value: string): string {
+  return value
+    .split("+")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .join(" + ");
+}
+
+// Return the hint letter that a bare single-key pattern (no modifiers/history)
+// would type, or null. Covers letters, digits, and punctuation across common
+// keyboard layouts via `keyCodeToChars`.
+function conflictingHintChar(value: string, hints: string): string | null {
+  const n = normalizeKeyPattern(value);
+  if (n === "" || n.includes(" + ")) return null;
+  return keyCodeToChars(n).find((c) => hints.includes(c.toLowerCase())) ?? null;
+}
+
+function computeKeyConflicts(values: Record<string, string>): {
+  messages: string[];
+  invalid: Set<string>;
+} {
+  const messages: string[] = [];
+  const invalid = new Set<string>();
+
+  for (const [a, b] of KEY_PAIR_CONFLICTS) {
+    const va = normalizeKeyPattern(values[a] ?? "");
+    const vb = normalizeKeyPattern(values[b] ?? "");
+    if (va !== "" && va === vb) {
+      messages.push(
+        `${KEY_LABELS[a]} and ${KEY_LABELS[b]} are both bound to "${va}".`,
+      );
+      invalid.add(a);
+      invalid.add(b);
+    }
+  }
+
+  const hints = (values.hints ?? "").toLowerCase();
+  for (const name of HINTS_VS_KEYS) {
+    const ch = conflictingHintChar(values[name] ?? "", hints);
+    if (ch) {
+      messages.push(`${KEY_LABELS[name]} ("${ch}") is also a Hint Letter.`);
+      invalid.add(name);
+      invalid.add("hints");
+    }
+  }
+
+  return { messages, invalid };
+}
+
+function initKeyConflictValidation(body: HTMLElement) {
+  const inputs = new Map<string, HTMLInputElement>();
+  for (const name of Object.keys(KEY_LABELS)) {
+    const el = body.querySelector<HTMLInputElement>(`[name="${name}"]`);
+    if (el) inputs.set(name, el);
+  }
+  const summary = document.querySelector<HTMLElement>("#key-conflicts");
+
+  const validate = () => {
+    const values: Record<string, string> = {};
+    for (const [name, el] of inputs) values[name] = el.value;
+    const { messages, invalid } = computeKeyConflicts(values);
+
+    for (const [name, el] of inputs) {
+      el.setCustomValidity(
+        invalid.has(name) ? "This key conflicts with another setting." : "",
+      );
+    }
+
+    if (!summary) return;
+    summary.replaceChildren();
+    summary.hidden = messages.length === 0;
+    if (messages.length === 0) return;
+
+    const title = document.createElement("strong");
+    title.textContent = "Key configuration conflicts:";
+    const ul = document.createElement("ul");
+    for (const msg of messages) {
+      const li = document.createElement("li");
+      li.textContent = msg;
+      ul.appendChild(li);
+    }
+    summary.append(title, ul);
+  };
+
+  body.addEventListener("input", validate);
+  body.addEventListener("change", validate);
+  validate();
 }
 
 interface ValueContaienrElement extends HTMLElement {

--- a/src/options.ts
+++ b/src/options.ts
@@ -209,18 +209,31 @@ function initClearButton(body: HTMLElement) {
 // force an empty value to disable a key such as the Magic Key.
 function initValuesetButton(body: HTMLElement) {
   for (const element of body.querySelectorAll("[data-valueset-target]")) {
-    if (!(element instanceof HTMLElement)) continue;
+    if (!(element instanceof HTMLButtonElement)) continue;
     console.log("valueset button: ", element);
+    const targetSelector = element.dataset.valuesetTarget;
+    if (!targetSelector) continue;
+    const value = element.dataset.valueset ?? "";
+
     element.addEventListener("click", () => {
-      const targetSelector = element.dataset.valuesetTarget;
-      if (!targetSelector) return;
-      const value = element.dataset.valueset ?? "";
       for (const target of document.querySelectorAll(targetSelector)) {
         console.log("valueset: ", target, value);
         (target as HTMLInputElement).value = value;
         dispatchChangeEvent(target as HTMLElement);
       }
     });
+
+    // Disable the button while every target already holds the value (e.g. an
+    // already-unbound key), since clicking it would be a no-op.
+    const syncDisabled = () => {
+      const targets =
+        document.querySelectorAll<HTMLInputElement>(targetSelector);
+      element.disabled =
+        targets.length > 0 && [...targets].every((t) => t.value === value);
+    };
+    body.addEventListener("input", syncDisabled);
+    body.addEventListener("change", syncDisabled);
+    syncDisabled();
   }
 }
 

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -2,6 +2,9 @@ declare interface Settings {
   magicKey: string;
   hints: string;
   blurKey: string;
+  stickyKey: string;
+  actionKey: string;
+  cancelKey: string;
   css: string;
   blackList: string;
   additionalSelectors: string;

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -57,6 +57,30 @@ export { expect };
 // ---------------------------------------------------------------------------
 
 /**
+ * Set extension settings via the background service worker.
+ * Only pass the keys you want to change; others remain untouched.
+ */
+export async function setSettings(
+  context: BrowserContext,
+  settings: Record<string, string>,
+): Promise<void> {
+  const sw = context.serviceWorkers()[0];
+  // chrome is available at runtime in the service worker; not known to TS here.
+  await sw.evaluate(
+    (s) =>
+      new Promise<void>((resolve) => {
+        interface SW {
+          chrome: {
+            storage: { sync: { set(i: typeof s, cb: () => void): void } };
+          };
+        }
+        (globalThis as unknown as SW).chrome.storage.sync.set(s, resolve);
+      }),
+    settings,
+  );
+}
+
+/**
  * Navigate to a test page and wait until the content script is ready
  * (the document has finished loading).
  */
@@ -74,6 +98,18 @@ export async function gotoTest(page: Page, name: string): Promise<void> {
 export async function attachHints(page: Page): Promise<void> {
   await page.keyboard.down("Space");
   // Hint elements live inside a shadow root; Playwright auto-pierces open shadows.
+  await expect(page.locator(".hint").first()).toBeVisible({ timeout: 5_000 });
+}
+
+/**
+ * Press and release the sticky key to activate hints in sticky mode.
+ * Hints should remain visible after the key is released.
+ */
+export async function attachHintsSticky(
+  page: Page,
+  stickyKey: string,
+): Promise<void> {
+  await page.keyboard.press(stickyKey);
   await expect(page.locator(".hint").first()).toBeVisible({ timeout: 5_000 });
 }
 

--- a/test/e2e/sticky-mode.spec.ts
+++ b/test/e2e/sticky-mode.spec.ts
@@ -1,0 +1,87 @@
+import {
+  test,
+  expect,
+  gotoTest,
+  attachHintsSticky,
+  findHintFor,
+  setSettings,
+} from "./fixtures.ts";
+
+// Use keys unlikely to conflict with the default magicKey (Space).
+const STICKY_KEY = "KeyQ";
+const ACTION_KEY = "Enter";
+const CANCEL_KEY = "Escape";
+
+test.describe("sticky mode", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await setSettings(context, {
+      stickyKey: STICKY_KEY,
+      actionKey: ACTION_KEY,
+      cancelKey: CANCEL_KEY,
+    });
+    await gotoTest(page, "input.html");
+  });
+
+  test.afterEach(async ({ context }) => {
+    // Reset to defaults so other tests are not affected.
+    await setSettings(context, { stickyKey: "", actionKey: "", cancelKey: "" });
+  });
+
+  test("sticky key attaches hints and releasing it keeps hints visible", async ({
+    page,
+  }) => {
+    await attachHintsSticky(page, STICKY_KEY);
+    // After pressing + releasing the sticky key, hints must still be visible.
+    await expect(page.locator(".hint").first()).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("action key fires the hit target's action", async ({ page }) => {
+    await attachHintsSticky(page, STICKY_KEY);
+    const hintText = await findHintFor(page, "input[type=text]");
+    for (const ch of hintText) {
+      await page.keyboard.press(ch);
+    }
+    await page.keyboard.press(ACTION_KEY);
+
+    await expect(page.locator("input[type=text]").first()).toBeFocused({
+      timeout: 3_000,
+    });
+  });
+
+  test("cancel key removes hints without firing any action", async ({
+    page,
+  }) => {
+    const checkbox = page.locator("input[type=checkbox]").first();
+    const checkedBefore = await checkbox.isChecked();
+
+    await attachHintsSticky(page, STICKY_KEY);
+    const hintText = await findHintFor(page, "input[type=checkbox]");
+    for (const ch of hintText) {
+      await page.keyboard.press(ch);
+    }
+    await page.keyboard.press(CANCEL_KEY);
+
+    await expect(page.locator(".hint").first()).not.toBeVisible({
+      timeout: 3_000,
+    });
+    // Checkbox must not have toggled.
+    expect(await checkbox.isChecked()).toBe(checkedBefore);
+  });
+
+  test("action key also fires for a magic key hold session", async ({
+    page,
+  }) => {
+    await page.keyboard.down("Space");
+    await expect(page.locator(".hint").first()).toBeVisible({ timeout: 5_000 });
+    const hintText = await findHintFor(page, "input[type=text]");
+    for (const ch of hintText) {
+      await page.keyboard.press(ch);
+    }
+    await page.keyboard.press(ACTION_KEY);
+    await page.keyboard.up("Space");
+
+    await expect(page.locator("input[type=text]").first()).toBeFocused({
+      timeout: 3_000,
+    });
+  });
+});

--- a/test/e2e/sticky-mode.spec.ts
+++ b/test/e2e/sticky-mode.spec.ts
@@ -68,6 +68,32 @@ test.describe("sticky mode", () => {
     expect(await checkbox.isChecked()).toBe(checkedBefore);
   });
 
+  test("second sticky session works after an action steals focus", async ({
+    page,
+  }) => {
+    // First session: fire the action with the Action Key DOWN only and never
+    // send its keyup, simulating a target=_blank action that opens a new tab
+    // and steals focus before keyup arrives. The window then loses focus.
+    await attachHintsSticky(page, STICKY_KEY);
+    const hintText1 = await findHintFor(page, "input[type=checkbox]");
+    for (const ch of hintText1) {
+      await page.keyboard.press(ch);
+    }
+    await page.keyboard.down(ACTION_KEY);
+    await expect(page.locator(".hint").first()).not.toBeVisible({
+      timeout: 3_000,
+    });
+
+    // Second session: hints must appear and stay visible after one hint letter,
+    // i.e. the stuck Action Key must not spuriously fire removeHints.
+    await attachHintsSticky(page, STICKY_KEY);
+    const hintText2 = await findHintFor(page, "input[type=text]");
+    await page.keyboard.press(hintText2[0]);
+    await expect(page.locator(".hint").first()).toBeVisible({ timeout: 3_000 });
+
+    await page.keyboard.up(ACTION_KEY).catch(() => void 0);
+  });
+
   test("action key also fires for a magic key hold session", async ({
     page,
   }) => {

--- a/test/lib/key-chars.test.ts
+++ b/test/lib/key-chars.test.ts
@@ -1,0 +1,30 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { keyCodeToChars } from "../../src/lib/key-chars.ts";
+
+void describe("keyCodeToChars", () => {
+  void test("maps letter codes to lowercase letters", () => {
+    assert.deepStrictEqual(keyCodeToChars("KeyA"), ["a"]);
+    assert.deepStrictEqual(keyCodeToChars("KeyZ"), ["z"]);
+  });
+
+  void test("maps digit codes to digit characters", () => {
+    assert.deepStrictEqual(keyCodeToChars("Digit1"), ["1"]);
+    assert.deepStrictEqual(keyCodeToChars("Numpad0"), ["0"]);
+  });
+
+  void test("maps punctuation codes across US and JIS layouts", () => {
+    // Semicolon only differs on US (";").
+    assert.deepStrictEqual(keyCodeToChars("Semicolon"), [";"]);
+    // Quote yields "'" on US and ":" on JIS.
+    assert.deepStrictEqual(keyCodeToChars("Quote"), ["'", ":"]);
+    // BracketLeft yields "[" on US and "@" on JIS.
+    assert.deepStrictEqual(keyCodeToChars("BracketLeft"), ["[", "@"]);
+  });
+
+  void test("returns empty for unknown / non-typing codes", () => {
+    assert.deepStrictEqual(keyCodeToChars("Enter"), []);
+    assert.deepStrictEqual(keyCodeToChars("Escape"), []);
+    assert.deepStrictEqual(keyCodeToChars("F1"), []);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Sticky Mode** as an alternative to the existing Magic Key hold interaction, makes the **Magic Key optional**, and adds **key configuration conflict validation** to the options page.

Fix #28 

## Interaction model

Knavi now supports two ways to drive hints:

- **Magic Key (hold)** — hold the Magic Key to show hints, type a hint's letters, then release the Magic Key to run the action. This is the original behavior and is unchanged.
- **Sticky Mode** — press the Sticky Key to show hints that stay visible without holding a key, then press the Action Key to run the action or the Cancel Key to dismiss them.

The Action Key and Cancel Key also work during a Magic Key hold session.

## Settings

| Setting | Default | Description |
|---|---|---|
| `magicKey` | `Space` | Hold to show hints; release to run the action. Now **optional** — can be set to empty (disabled) via the **Disable** button. |
| `stickyKey` | empty | Press to show sticky hints. |
| `actionKey` | empty | While hinting, runs the action on the matched element. |
| `cancelKey` | empty | While hinting, dismisses the hints without running any action. |
| `blurKey` | empty | While not hinting, deactivates the focused element. (Pre-existing.) |
| `hints` | `asdfghjkl` | Characters used to label hints. (Pre-existing.) |

The three new keys default to empty (disabled), so existing behavior is unchanged out of the box.

## Key configuration conflict validation

The options page validates that bindings do not collide and highlights any conflict (the offending fields are marked invalid and a summary is shown).

The rule follows the phase in which each key fires:

- **While not hinting:** Magic Key, Sticky Key, Blur Key
- **While hinting:** Action Key, Cancel Key, hint letters
  (the Magic Key is also held throughout a hold session, so it overlaps the hinting phase as well)

Two keys conflict only if their active phases can overlap. Concretely:

- **Magic Key** must differ from **every** other key (it spans both phases).
- **Sticky Key** and **Blur Key** must differ from each other and from the Magic Key (all fire while not hinting), but **may share a binding** with the Action/Cancel keys and hint letters (which only fire while hinting).
- **Action Key**, **Cancel Key**, and **hint letters** must be mutually distinct.

Conflict matrix (✗ = must differ, — = allowed):

|            | magic | sticky | blur | hints | action | cancel |
|------------|:-----:|:------:|:----:|:-----:|:------:|:------:|
| **magic**  |  —    | ✗      | ✗    | ✗     | ✗      | ✗      |
| **sticky** | ✗     | —      | ✗    | —     | —      | —      |
| **blur**   | ✗     | ✗      | —    | —     | —      | —      |
| **hints**  | ✗     | —      | —    | —     | ✗      | ✗      |
| **action** | ✗     | —      | —    | ✗     | —      | ✗      |
| **cancel** | ✗     | —      | —    | ✗     | ✗      | —      |

Hint-letter comparison handles symbol keys whose `event.code` maps to different characters across keyboard layouts (US ANSI / JIS), over-approximating to avoid missing a conflict.

## Notable fix

Sticky Mode could break after an action that steals focus (e.g. a `target=_blank` link opening a new tab):

- The content-root hinter kept its context and aggregation callback until the awaited `ExecuteAction` round-trip finished, so a second `AttachHints` arriving meanwhile threw. The state is now cleared synchronously before the await.
- A keydown action that steals focus loses its keyup, leaving the key stuck in the matcher history and spuriously matching on the next session. The matchers are now reset when a hint session ends.

## Testing

- `npm run fix && npm run lint && npm run test` pass.
- E2E (`test/e2e/sticky-mode.spec.ts`) covers sticky attach/persist, action, cancel, the Action Key working for Magic Key sessions, and a regression test reproducing the focus-stealing action via a keydown-only action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
