### PR TITLE
Implement action popup for blacklist

### DIFF
--- a/changelog/4.0.0.md
+++ b/changelog/4.0.0.md
@@ -13,6 +13,13 @@
   - Press the Action Key to run the action, or the Cancel Key to dismiss
   - The Action Key and Cancel Key also work during a Magic Key hold session
   - Configure the new keys in the option page (all disabled by default)
+- Add a toolbar popup to blacklist the current site or URL
+  - Click the toolbar icon to toggle the current site (`<origin>/*`) or the
+    current URL (`<origin><path>*`) in the blacklist
+  - The toolbar icon dims on pages where KNavi is disabled (blacklisted or
+    non-http(s) pages)
+  - The popup uses these canonical pattern shapes, so a pattern added here may
+    differ from one added by hand in the option page; both still apply
 - Make the Magic Key optional (press "Unbind" in the option page to turn it off)
 - Validate key configuration conflicts in the option page
 - Fix

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -18,7 +18,13 @@ const ROOT = path.join(__dirname, "..");
 const SRC = path.join(ROOT, "src");
 const BUILD = path.join(ROOT, "build");
 
-const JS_ENTRIES = ["background", "content-root", "content-all", "options"];
+const JS_ENTRIES = [
+  "background",
+  "content-root",
+  "content-all",
+  "options",
+  "popup",
+];
 const ICON_WIDTHS = [16, 48, 128];
 
 export interface BuildOptions {
@@ -44,14 +50,22 @@ export async function build({
     }
   }
 
-  // Generate icons from icon.svg.
+  // Generate icons from icon.svg and icon-disabled.svg at toolbar widths.
+  const TOOLBAR_ICONS = ["icon", "icon-disabled"];
   for (const w of ICON_WIDTHS) {
-    convertSvg(path.join(SRC, "icon.svg"), path.join(BUILD, `icon${w}.png`), w);
+    for (const name of TOOLBAR_ICONS) {
+      convertSvg(
+        path.join(SRC, `${name}.svg`),
+        path.join(BUILD, `${name}${w}.png`),
+        w,
+      );
+    }
   }
 
   // Generate other PNGs from the remaining SVGs (width 40).
+  const skip = new Set(TOOLBAR_ICONS.map((n) => `${n}.svg`));
   for (const file of readdirSync(SRC)) {
-    if (file.endsWith(".svg") && file !== "icon.svg") {
+    if (file.endsWith(".svg") && !skip.has(file)) {
       const name = path.basename(file, ".svg");
       convertSvg(path.join(SRC, file), path.join(BUILD, `${name}.png`), 40);
     }

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,11 +2,13 @@ import * as rectAggregator from "./background/rect-aggregator";
 import * as hinter from "./background/hinter";
 import * as settings from "./background/settings";
 import * as migration from "./background/migration";
+import * as actionIcon from "./background/action-icon";
 import libSettings from "./lib/settings";
 
 globalThis.KNAVI_FILE = "background";
 
 migration.init(libSettings);
+actionIcon.init();
 
 chrome.runtime.onMessage.addListener(
   rectAggregator.router

--- a/src/background/action-icon.ts
+++ b/src/background/action-icon.ts
@@ -1,0 +1,78 @@
+import settings from "../lib/settings";
+import { BlackList } from "../lib/blacklist";
+import { printError } from "../lib/errors";
+
+const ENABLED_ICON = {
+  16: "icon16.png",
+  48: "icon48.png",
+  128: "icon128.png",
+};
+const DISABLED_ICON = {
+  16: "icon-disabled16.png",
+  48: "icon-disabled48.png",
+  128: "icon-disabled128.png",
+};
+
+let cachedList: BlackList | undefined;
+
+async function loadBlackList(): Promise<BlackList> {
+  if (cachedList) return cachedList;
+  const storage = await settings.init();
+  cachedList = new BlackList(await storage.getSingle("blackList"));
+  return cachedList;
+}
+
+function isDisabled(url: string | undefined, list: BlackList): boolean {
+  if (!url) return true;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return true;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return true;
+  return list.match(url).length > 0;
+}
+
+async function updateTab(
+  tabId: number,
+  url: string | undefined,
+  list: BlackList,
+) {
+  await chrome.action.setIcon({
+    tabId,
+    path: isDisabled(url, list) ? DISABLED_ICON : ENABLED_ICON,
+  });
+}
+
+async function updateActiveTabs() {
+  const list = await loadBlackList();
+  const tabs = await chrome.tabs.query({ active: true });
+  await Promise.all(
+    tabs
+      .filter((t) => t.id != null)
+      .map((t) => updateTab(t.id!, t.url, list).catch(printError)),
+  );
+}
+
+export function init() {
+  chrome.tabs.onActivated.addListener(({ tabId }) => {
+    Promise.all([chrome.tabs.get(tabId), loadBlackList()])
+      .then(([t, list]) => updateTab(tabId, t.url, list))
+      .catch(printError);
+  });
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    const url = changeInfo.url;
+    if (!url) return;
+    loadBlackList()
+      .then((list) => updateTab(tabId, url, list))
+      .catch(printError);
+  });
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "sync" && area !== "local") return;
+    if (!("blackList" in changes)) return;
+    cachedList = undefined;
+    updateActiveTabs().catch(printError);
+  });
+  updateActiveTabs().catch(printError);
+}

--- a/src/background/action-icon.ts
+++ b/src/background/action-icon.ts
@@ -61,11 +61,13 @@ export function init() {
       .then(([t, list]) => updateTab(tabId, t.url, list))
       .catch(printError);
   });
-  chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-    const url = changeInfo.url;
-    if (!url) return;
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    // The exact onUpdated firing behavior (e.g. for history.pushState/
+    // replaceState navigations) is not documented, so we react broadly to any
+    // URL/status change and re-evaluate from the tab's current URL.
+    if (changeInfo.url == null && changeInfo.status == null) return;
     loadBlackList()
-      .then((list) => updateTab(tabId, url, list))
+      .then((list) => updateTab(tabId, tab.url, list))
       .catch(printError);
   });
   chrome.storage.onChanged.addListener((changes, area) => {

--- a/src/background/action-icon.ts
+++ b/src/background/action-icon.ts
@@ -17,8 +17,10 @@ let cachedList: BlackList | undefined;
 
 async function loadBlackList(): Promise<BlackList> {
   if (cachedList) return cachedList;
-  const storage = await settings.init();
-  cachedList = new BlackList(await storage.getSingle("blackList"));
+  // Read-only: use readonlyStorage() so updating the icon never back-fills
+  // default settings, which could clobber a concurrent write at startup.
+  const storage = await settings.readonlyStorage();
+  cachedList = new BlackList((await storage.getSingle("blackList")) ?? "");
   return cachedList;
 }
 

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -1,8 +1,14 @@
 import settings from "../lib/settings";
-import { BlackList } from "../lib/blacklist";
+import { BlackList, togglePattern } from "../lib/blacklist";
 import { AdditionalSelectors } from "../lib/additional-selectors";
 import { Router } from "../lib/chrome-messages";
 import { printError } from "../lib/errors";
+
+// Serializes ToggleBlacklist read-modify-write so rapid toggles (e.g. quick
+// clicks in the popup) do not lose updates. Note this does not guard against
+// the options page, which saves the whole blacklist text directly rather than
+// going through this message.
+let toggleQueue: Promise<unknown> = Promise.resolve();
 
 chrome.storage.onChanged.addListener(() => {
   settings.init(true).catch(printError);
@@ -30,4 +36,18 @@ export const router = Router.newInstance()
       additionalSelectors = new AdditionalSelectors("{}");
     }
     return additionalSelectors.match(message.url);
+  })
+  .add("ToggleBlacklist", (message) => {
+    const run = async () => {
+      const storage = await settings.init();
+      const current = await storage.getSingle("blackList");
+      const { text, added } = togglePattern(current, message.pattern);
+      await storage.setSingle("blackList", text);
+      return { added };
+    };
+    // .then(run, run): run even if previous toggle failed, so a transient
+    // error doesn't permanently block the queue.
+    const next = toggleQueue.then(run, run);
+    toggleQueue = next.catch(() => undefined);
+    return next;
   });

--- a/src/icon-disabled.svg
+++ b/src/icon-disabled.svg
@@ -1,0 +1,40 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  viewBox="0 0 160 160"
+>
+  <defs>
+    <g id="keytop">
+      <rect rx="10" ry="10" width="100" height="100" fill="#999" />
+    </g>
+    <g id="keytops-row">
+      <use xlink:href="#keytop" x="0" y="0" />
+      <use xlink:href="#keytop" x="120" y="0" />
+      <use xlink:href="#keytop" x="240" y="0" />
+      <use xlink:href="#keytop" x="360" y="0" />
+    </g>
+    <g id="keytops">
+      <rect x="0" y="0" height="500" width="500" fill="#dcdcdc" />
+      <use x="0" y="0" xlink:href="#keytops-row" />
+      <use x="35" y="115" xlink:href="#keytops-row" />
+      <use x="90" y="230" xlink:href="#keytops-row" />
+      <text
+        x="182"
+        y="186"
+        font-family="Verdana"
+        font-size="57"
+        font-weight="bold"
+        fill="#cfcfcf"
+      >K</text>
+    </g>
+    <g id="offset-keytops">
+      <use xlink:href="#keytops" x="-125" y="-85" />
+    </g>
+    <clipPath id="radius-rect-clip">
+      <rect x="0" y="0" width="160" height="160" rx="18" ry="18" />
+    </clipPath>
+  </defs>
+  <g opacity="0.55">
+    <use xlink:href="#offset-keytops" clip-path="url(#radius-rect-clip)" />
+  </g>
+</svg>

--- a/src/lib/blacklist.ts
+++ b/src/lib/blacklist.ts
@@ -1,11 +1,12 @@
 import GlobTrie from "glob-trie.js";
-import { filter, map, reduce } from "./iters";
 
 export class BlackList {
   private patterns: GlobTrie<string>;
 
   constructor(text: string) {
-    this.patterns = parse(text);
+    const gt = new GlobTrie<string>();
+    for (const p of parsePatterns(text)) gt.add(p, p);
+    this.patterns = gt;
   }
 
   match(url: string) {
@@ -13,16 +14,31 @@ export class BlackList {
   }
 }
 
-function parse(text: string) {
-  return reduce(
-    filter(
-      map(text.split("\n"), (s) => s.trim()),
-      (s) => !s.startsWith("#") && s.length > 0,
-    ),
-    (gt, s) => {
-      gt.add(s, s);
-      return gt;
-    },
-    new GlobTrie(),
-  );
+/** Returns the normalized, non-comment, non-empty pattern lines. */
+export function parsePatterns(text: string): string[] {
+  return text
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith("#"));
+}
+
+/**
+ * Toggle a pattern in the blacklist text while preserving comments and
+ * blank lines. The pattern is matched against trimmed lines.
+ */
+export function togglePattern(
+  text: string,
+  pattern: string,
+): { text: string; added: boolean } {
+  const target = pattern.trim();
+  const lines = text.split("\n");
+  const kept = lines.filter((line) => line.trim() !== target);
+  if (kept.length !== lines.length) {
+    return { text: kept.join("\n"), added: false };
+  }
+  const needsLeadingNewline = text.length > 0 && !text.endsWith("\n");
+  return {
+    text: text + (needsLeadingNewline ? "\n" : "") + target + "\n",
+    added: true,
+  };
 }

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -15,6 +15,10 @@ interface Messages {
     payload: { url: string };
     response: string[];
   };
+  ToggleBlacklist: {
+    payload: { pattern: string };
+    response: { added: boolean };
+  };
 
   // Hint
   AttachHints: {

--- a/src/lib/settings-client.ts
+++ b/src/lib/settings-client.ts
@@ -10,4 +10,7 @@ export default {
   matchAdditionalSelectors(url: string): Promise<string[]> {
     return sendToRuntime("MatchAdditionalSelectors", { url });
   },
+  toggleBlacklist(pattern: string): Promise<{ added: boolean }> {
+    return sendToRuntime("ToggleBlacklist", { pattern });
+  },
 };

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -125,6 +125,13 @@ export default {
     await storage.init();
     return storage;
   },
+  // Returns the active storage area without running init(). Use this for
+  // read-only consumers that must not trigger the default-value back-fill,
+  // whose non-atomic read-modify-write can clobber a concurrent settings
+  // write (e.g. during startup).
+  async readonlyStorage(): Promise<Storage> {
+    return getStorage();
+  },
   async defaults(): Promise<Settings> {
     return {
       ...DEFAULT_SETTINGS,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -36,6 +36,14 @@ export default function manifest(pkg: Pkg): chrome.runtime.ManifestV3 {
       page: "options.html",
       open_in_tab: true,
     },
+    action: {
+      default_popup: "popup.html",
+      default_icon: {
+        16: "icon16.png",
+        48: "icon48.png",
+        128: "icon128.png",
+      },
+    },
     permissions: ["storage"],
     host_permissions: ["<all_urls>"],
     web_accessible_resources: [

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,88 @@
+body {
+  width: 300px;
+  margin: 0;
+  padding: 12px;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 14px;
+  background-color: #fff;
+  color: #333;
+}
+
+.status {
+  padding: 8px 10px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.status.enabled {
+  background-color: #e6f4ea;
+  color: #1e8e3e;
+}
+
+.status.disabled,
+.status.error {
+  background-color: #fce8e6;
+  color: #c5221f;
+}
+
+.btn {
+  display: block;
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 8px;
+  border: 1px solid #dadce0;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #3c4043;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+  transition: background-color 0.15s;
+}
+
+.btn:hover:not(:disabled) {
+  background-color: #f8f9fa;
+}
+
+.btn:active:not(:disabled) {
+  background-color: #e8eaed;
+}
+
+.btn.is-removed {
+  border-color: #c5221f;
+  color: #c5221f;
+}
+
+.btn.is-removed:hover:not(:disabled) {
+  background-color: #fce8e6;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn[hidden] {
+  display: none;
+}
+
+.btn-reload {
+  text-align: center;
+  margin-top: 4px;
+  color: #1967d2;
+  border-color: #c4d8fc;
+}
+
+.pattern {
+  display: block;
+  font-family: Consolas, Menlo, Monaco, monospace;
+  font-size: 11px;
+  color: #80868b;
+  margin-top: 4px;
+  word-break: break-all;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" type="text/css" href="popup.css" />
+    <script src="popup.js" async></script>
+  </head>
+  <body>
+    <div id="status" class="status"></div>
+    <button id="blacklist-site" class="btn">
+      <span class="btn-label">Blacklist site</span>
+      <span id="site-pattern" class="pattern"></span>
+    </button>
+    <button id="blacklist-url" class="btn">
+      <span class="btn-label">Blacklist URL</span>
+      <span id="url-pattern" class="pattern"></span>
+    </button>
+    <button id="reload" class="btn btn-reload" hidden>
+      <span class="btn-label">Reload page</span>
+    </button>
+  </body>
+</html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,0 +1,157 @@
+import settingsClient from "./lib/settings-client";
+import { BlackList, parsePatterns } from "./lib/blacklist";
+import { printError } from "./lib/errors";
+
+interface PopupUI {
+  statusEl: HTMLElement;
+  siteButton: HTMLButtonElement;
+  urlButton: HTMLButtonElement;
+  siteLabel: HTMLElement;
+  urlLabel: HTMLElement;
+  reloadButton: HTMLButtonElement;
+}
+
+function updateButtonState(
+  button: HTMLButtonElement,
+  label: string,
+  isPresent: boolean,
+) {
+  const labelEl = button.querySelector(".btn-label");
+  if (!labelEl) throw new Error("button is missing its .btn-label element");
+  if (isPresent) {
+    labelEl.textContent = `Remove ${label} from blacklist`;
+    button.classList.add("is-removed");
+  } else {
+    labelEl.textContent = `Blacklist ${label}`;
+    button.classList.remove("is-removed");
+  }
+}
+
+function refreshStatus(
+  ui: PopupUI,
+  blackListRaw: string,
+  url: URL,
+  sitePattern: string,
+  urlPattern: string,
+) {
+  const blackList = new BlackList(blackListRaw);
+  const patterns = parsePatterns(blackListRaw);
+
+  updateButtonState(ui.siteButton, "site", patterns.includes(sitePattern));
+  updateButtonState(ui.urlButton, "URL", patterns.includes(urlPattern));
+
+  const matches = blackList.match(url.toString());
+  if (matches.length > 0) {
+    const matchedByButtonPattern =
+      matches.includes(sitePattern) || matches.includes(urlPattern);
+    ui.statusEl.textContent = matchedByButtonPattern
+      ? "Disabled (blacklisted)"
+      : `Disabled (matched: ${matches[0]})`;
+    ui.statusEl.className = "status disabled";
+  } else {
+    ui.statusEl.textContent = "Enabled";
+    ui.statusEl.className = "status enabled";
+  }
+}
+
+async function init() {
+  const ui = initUI();
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  let url: URL;
+  try {
+    url = new URL(tab?.url ?? tab?.pendingUrl ?? "");
+  } catch {
+    showInvalidPage(ui);
+    return;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    showInvalidPage(ui);
+    return;
+  }
+
+  // The popup always uses these canonical pattern forms. A user may have
+  // blacklisted the same page in a different shape via the options page, in
+  // which case the toggle here adds a separate line rather than reusing it.
+  const sitePattern = `${url.origin}/*`;
+  const urlPattern = `${url.origin}${url.pathname}*`;
+
+  ui.siteLabel.textContent = sitePattern;
+  ui.urlLabel.textContent = urlPattern;
+
+  const blackListRaw =
+    (await settingsClient.get(["blackList"])).blackList ?? "";
+  refreshStatus(ui, blackListRaw, url, sitePattern, urlPattern);
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "sync" && area !== "local") return;
+    if (!("blackList" in changes)) return;
+    const newValue = (changes.blackList.newValue as string) ?? "";
+    refreshStatus(ui, newValue, url, sitePattern, urlPattern);
+  });
+
+  ui.siteButton.addEventListener("click", () => {
+    void togglePattern(sitePattern, ui, tab.id);
+  });
+  ui.urlButton.addEventListener("click", () => {
+    void togglePattern(urlPattern, ui, tab.id);
+  });
+  ui.reloadButton.addEventListener("click", () => {
+    if (tab.id != null) {
+      chrome.tabs.reload(tab.id, () => window.close());
+    } else {
+      window.close();
+    }
+  });
+}
+
+function initUI(): PopupUI {
+  const statusEl = document.getElementById("status");
+  const siteButton = document.getElementById("blacklist-site");
+  const urlButton = document.getElementById("blacklist-url");
+  const siteLabel = document.getElementById("site-pattern");
+  const urlLabel = document.getElementById("url-pattern");
+  const reloadButton = document.getElementById("reload");
+  if (
+    !(statusEl instanceof HTMLElement) ||
+    !(siteButton instanceof HTMLButtonElement) ||
+    !(urlButton instanceof HTMLButtonElement) ||
+    !(siteLabel instanceof HTMLElement) ||
+    !(urlLabel instanceof HTMLElement) ||
+    !(reloadButton instanceof HTMLButtonElement)
+  ) {
+    throw new Error("popup.html is missing expected elements");
+  }
+  return { statusEl, siteButton, urlButton, siteLabel, urlLabel, reloadButton };
+}
+
+function showInvalidPage(ui: PopupUI) {
+  ui.statusEl.textContent = "Not available on this page";
+  ui.statusEl.className = "status disabled";
+  ui.siteButton.disabled = true;
+  ui.urlButton.disabled = true;
+  ui.siteLabel.textContent = "";
+  ui.urlLabel.textContent = "";
+}
+
+async function togglePattern(
+  pattern: string,
+  ui: PopupUI,
+  tabId: number | undefined,
+) {
+  ui.siteButton.disabled = true;
+  ui.urlButton.disabled = true;
+  try {
+    await settingsClient.toggleBlacklist(pattern);
+    if (tabId != null) ui.reloadButton.hidden = false;
+  } catch (e) {
+    printError(e);
+    ui.statusEl.textContent = "Failed to update blacklist";
+    ui.statusEl.className = "status error";
+  } finally {
+    ui.siteButton.disabled = false;
+    ui.urlButton.disabled = false;
+  }
+}
+
+init().catch(printError);

--- a/src/tsconfig.dom-app.json
+++ b/src/tsconfig.dom-app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["chrome"]
+  }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "tsconfig.dom.json" },
     { "path": "tsconfig.content-all.json" },
     { "path": "tsconfig.content-root.json" },
-    { "path": "tsconfig.options.json" }
+    { "path": "tsconfig.options.json" },
+    { "path": "tsconfig.popup.json" }
   ]
 }

--- a/src/tsconfig.popup.json
+++ b/src/tsconfig.popup.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.dom-app.json",
-  "include": ["options.ts", "options", "types"],
+  "include": ["popup.ts", "types"],
   "references": [
     { "path": "tsconfig.lib.json" },
     { "path": "tsconfig.dom.json" }

--- a/test/lib/blacklist.test.ts
+++ b/test/lib/blacklist.test.ts
@@ -1,6 +1,10 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { BlackList } from "../../src/lib/blacklist";
+import {
+  BlackList,
+  parsePatterns,
+  togglePattern,
+} from "../../src/lib/blacklist";
 
 const patterns = `https://www.google.co.jp/search
 https://twitter.com/*/status/*`;
@@ -21,5 +25,82 @@ void describe("BlackList", () => {
       assert.deepStrictEqual(bl.match("https://twitter.com/k_ui"), []);
       assert.deepStrictEqual(bl.match("https://www.google.co.jp"), []);
     });
+  });
+});
+
+void describe("parsePatterns", () => {
+  void test("trims lines and drops empty and comment lines", () => {
+    const text = `# comment
+  https://example.com/*
+
+\thttps://foo.com/bar
+# another comment`;
+    assert.deepStrictEqual(parsePatterns(text), [
+      "https://example.com/*",
+      "https://foo.com/bar",
+    ]);
+  });
+
+  void test("returns an empty array for empty text", () => {
+    assert.deepStrictEqual(parsePatterns(""), []);
+  });
+});
+
+void describe("togglePattern", () => {
+  void test("adds to empty text", () => {
+    assert.deepStrictEqual(togglePattern("", "https://example.com/*"), {
+      text: "https://example.com/*\n",
+      added: true,
+    });
+  });
+
+  void test("adds a leading newline when text has no trailing newline", () => {
+    assert.deepStrictEqual(
+      togglePattern("https://a.com/*", "https://b.com/*"),
+      { text: "https://a.com/*\nhttps://b.com/*\n", added: true },
+    );
+  });
+
+  void test("does not duplicate a trailing newline", () => {
+    assert.deepStrictEqual(
+      togglePattern("https://a.com/*\n", "https://b.com/*"),
+      { text: "https://a.com/*\nhttps://b.com/*\n", added: true },
+    );
+  });
+
+  void test("removes an existing pattern preserving surrounding comments", () => {
+    const text = `# keep me
+https://a.com/*
+https://b.com/*
+# trailing comment`;
+    assert.deepStrictEqual(togglePattern(text, "https://a.com/*"), {
+      text: `# keep me
+https://b.com/*
+# trailing comment`,
+      added: false,
+    });
+  });
+
+  void test("matches against trimmed lines when removing", () => {
+    const text = "  https://a.com/*  \nhttps://b.com/*\n";
+    const { added } = togglePattern(text, "https://a.com/*");
+    assert.equal(added, false);
+  });
+
+  void test("removes all duplicate occurrences in one toggle", () => {
+    const text = "https://a.com/*\nhttps://b.com/*\nhttps://a.com/*\n";
+    assert.deepStrictEqual(togglePattern(text, "https://a.com/*"), {
+      text: "https://b.com/*\n",
+      added: false,
+    });
+  });
+
+  void test("round-trips add then remove back to original", () => {
+    const original = "https://a.com/*\n";
+    const added = togglePattern(original, "https://b.com/*");
+    assert.equal(added.added, true);
+    const removed = togglePattern(added.text, "https://b.com/*");
+    assert.equal(removed.added, false);
+    assert.equal(removed.text, original);
   });
 });


### PR DESCRIPTION
## Add toolbar action popup for managing the blacklist

### Summary

Adds a browser toolbar (action) popup that lets users blacklist or un-blacklist the current page directly, without opening the option page. The toolbar icon also reflects whether KNavi is active on the current tab.

### What's new

- **Toolbar popup** (`popup.html` / `popup.ts` / `popup.css`)
  - Toggle the current **site** (`<origin>/*`) or the current **URL** (`<origin><path>*`) in the blacklist with one click.
  - Shows the current status: `Enabled`, `Disabled (blacklisted)`, or `Disabled (matched: <pattern>)` when disabled by an unrelated existing pattern.
  - Includes a reload button to apply the change to the current tab.
  - Gracefully disables itself on non-http(s) / invalid pages.
  - Live-updates via `chrome.storage.onChanged` so the popup stays in sync if the blacklist changes elsewhere.

- **Action icon syncing** (`background/action-icon.ts`)
  - The toolbar icon dims (`icon-disabled*`) on pages where KNavi is disabled — blacklisted or non-http(s) pages — and shows the normal icon otherwise.
  - Reacts to tab activation, tab updates (including in-page `pushState`/`replaceState` navigations and reloads), and blacklist storage changes.

- **Blacklist helpers** (`lib/blacklist.ts`)
  - Extracted `parsePatterns()` for reuse between matching and the popup.
  - Added `togglePattern()`, which adds/removes a pattern while preserving comments and blank lines in the user's raw blacklist text.
  - Exposed `toggleBlacklist` through the settings client / chrome messages.

### Notes

- The popup always writes canonical pattern shapes (`<origin>/*`, `<origin><path>*`). A page blacklisted by hand in the option page with a different shape will show as disabled but won't be reused by the toggle — a separate line is added instead. This trade-off is documented in the changelog and inline.

### Build / manifest

- Registers the `action` entry (popup + default icons) in `manifest.ts`.
- Adds the disabled icon asset (`icon-disabled.svg`) and build/tsconfig wiring for the new popup DOM app.

### Tests

- Extended `test/lib/blacklist.test.ts` to cover `parsePatterns` and `togglePattern` (add/remove, comment/blank-line preservation, trailing-newline handling).

### Changelog

- Documented under `changelog/4.0.0.md`.
