### PR TITLE
Replace unmaintained glob-trie.js with in-tree TypeScript implementation

### DIFF
--- a/changelog/4.0.0.md
+++ b/changelog/4.0.0.md
@@ -19,3 +19,6 @@
   - Fix error when no active element is found
 - Small Changes
   - Make the option page in typescript
+  - Replace the unmaintained `glob-trie.js` dependency with an in-tree
+    TypeScript implementation, allowing strict mode for the content scripts
+    build

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "chokidar-cli": "^3.0.0",
         "esbuild": "0.28.0",
         "eslint": "^10.4.1",
-        "glob-trie.js": "^0.2.1",
         "globals": "^17.6.0",
         "http-server": "^14.1.1",
         "json5": "^2.2.3",
@@ -2637,15 +2636,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob-trie.js": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/glob-trie.js/-/glob-trie.js-0.2.1.tgz",
-      "integrity": "sha512-AUno8wRfNrvVkwNSS5Ihb0Eq66TSmxkZzGxMRuxd3VHkmYts/hC3PpJxZYpZuPEK4TQU7rpY/uX31qPmLMPs/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/globals": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "chokidar-cli": "^3.0.0",
     "esbuild": "0.28.0",
     "eslint": "^10.4.1",
-    "glob-trie.js": "^0.2.1",
     "globals": "^17.6.0",
     "http-server": "^14.1.1",
     "json5": "^2.2.3",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -65,7 +65,7 @@ export async function build({
     sourcemap: true,
     minify,
     target: "chrome100",
-    tsconfig: path.join(SRC, "tsconfig.esbuild.json"),
+    tsconfig: path.join(SRC, "tsconfig.content-all.json"),
     pure: [
       "console.debug",
       "console.log",

--- a/src/lib/additional-selectors.ts
+++ b/src/lib/additional-selectors.ts
@@ -1,5 +1,5 @@
 import JSON5 from "json5";
-import GlobTrie from "glob-trie.js";
+import GlobTrie from "./glob-trie";
 import { flatMap, reduce } from "./iters";
 
 export class AdditionalSelectors {

--- a/src/lib/blacklist.ts
+++ b/src/lib/blacklist.ts
@@ -1,4 +1,4 @@
-import GlobTrie from "glob-trie.js";
+import GlobTrie from "./glob-trie";
 import { filter, map, reduce } from "./iters";
 
 export class BlackList {
@@ -23,6 +23,6 @@ function parse(text: string) {
       gt.add(s, s);
       return gt;
     },
-    new GlobTrie(),
+    new GlobTrie<string>(),
   );
 }

--- a/src/lib/glob-trie.ts
+++ b/src/lib/glob-trie.ts
@@ -1,0 +1,175 @@
+// A search trie that can efficiently match a string against a large number of
+// glob patterns, each carrying an associated payload.
+//
+// This is a TypeScript reimplementation of the unmaintained `glob-trie.js`
+// package (https://github.com/rbranson/glob-trie.js) by Rick Branson, which
+// relied on an implicit global assignment that is illegal in strict mode.
+//
+// Supported pattern syntax:
+//
+//   *      matches any character 0 to infinity times
+//   ?      matches any character exactly once
+//   \      escapes *, ?, [ and ]
+//   [...]  matches a RegExp-compatible character class once
+//   anything else is matched at face value
+//
+
+// A compiled sub-expression. A plain string matches that exact character,
+// while the symbolic tokens below match wildcards, character classes and the
+// end of an expression.
+type Sexpr = string;
+
+const STAR = ":*";
+const ANY = ":?";
+const END = ":E";
+
+class Node<T> {
+  readonly children: Node<T>[] = [];
+  readonly payloads: T[] = [];
+  private matcher: RegExp | null | undefined;
+
+  constructor(
+    readonly parent: Node<T> | null = null,
+    readonly sexpr: Sexpr | null = null,
+  ) {}
+
+  isRoot(): boolean {
+    return this.parent == null;
+  }
+
+  // Returns a RegExp matching a single character against this node's character
+  // class sexpr (e.g. `:[abc]`), or null if this node is not a character class.
+  charClassMatcher(): RegExp | null {
+    if (this.matcher === undefined) {
+      const m = this.sexpr?.match(/^:\[(.*?)\]$/);
+      if (m) {
+        // Re-escape the guts so they are treated literally inside the class.
+        const guts = m[1].replace(/([[\]()*?.\\])/g, "\\$1");
+        this.matcher = new RegExp("^[" + guts + "]$");
+      } else {
+        this.matcher = null;
+      }
+    }
+    return this.matcher;
+  }
+}
+
+// Parses an expression into an array of valid sexprs.
+function compile(expr: string): Sexpr[] {
+  const out: Sexpr[] = [];
+  let inBracket = false;
+  let buf = "";
+
+  for (let i = 0; i < expr.length; i++) {
+    const c = expr.charAt(i);
+
+    if (c === "\\") {
+      const nextc = expr.charAt(++i);
+      if (inBracket) {
+        buf += nextc;
+      } else {
+        out.push(nextc);
+      }
+    } else if (inBracket) {
+      if (c === "]") {
+        out.push(":[" + buf + "]");
+        inBracket = false;
+        buf = "";
+      } else {
+        buf += c;
+      }
+    } else {
+      switch (c) {
+        case "[":
+          inBracket = true;
+          buf = "";
+          break;
+        case "]":
+          throw new Error(
+            "GlobTrie.compile error: stray right bracket encountered.",
+          );
+        case "*":
+          out.push(STAR);
+          break;
+        case "?":
+          out.push(ANY);
+          break;
+        default:
+          out.push(c);
+          break;
+      }
+    }
+  }
+
+  out.push(END);
+  return out;
+}
+
+export default class GlobTrie<T> {
+  private readonly root = new Node<T>();
+
+  // Adds a payload to the trie for an expression.
+  add(expr: string, payload: T): void {
+    let node = this.root;
+    for (const sexpr of compile(expr)) {
+      let child = node.children.find((c) => c.sexpr === sexpr);
+      if (!child) {
+        child = new Node<T>(node, sexpr);
+        node.children.push(child);
+      }
+      node = child;
+    }
+    node.payloads.push(payload);
+  }
+
+  // Collects all the payloads found when searching the trie for a string.
+  collect(s: string): T[] {
+    const ret: T[] = [];
+    this.walk(this.root, s, 0, (node) => {
+      ret.push(...node.payloads);
+    });
+    return ret;
+  }
+
+  // Recursively walks the trie searching for `s`, calling `f` at each node
+  // whose path matches a full prefix of the string up to position `pos`.
+  private walk(
+    node: Node<T>,
+    s: string,
+    pos: number,
+    f: (node: Node<T>) => void,
+  ): void {
+    if (node.isRoot()) {
+      for (const child of node.children) {
+        this.walk(child, s, pos, f);
+      }
+      return;
+    }
+
+    const sexpr = node.sexpr;
+    if (sexpr == null) return;
+
+    const c = s.charAt(pos);
+    if (
+      c.length === 1 &&
+      (sexpr === c ||
+        sexpr === ANY ||
+        (sexpr.charAt(1) === "[" && node.charClassMatcher()?.test(c)))
+    ) {
+      // Matched a single-char wildcard, exact char, or character class.
+      for (const child of node.children) {
+        this.walk(child, s, pos + 1, f);
+      }
+    } else if (sexpr === STAR) {
+      // Match any character in the rest of the string, including zero chars.
+      for (let si = pos; si <= s.length; si++) {
+        for (const child of node.children) {
+          this.walk(child, s, si, f);
+        }
+      }
+    } else if (sexpr === END && pos === s.length) {
+      // Matched the end of the expression to the end of the string.
+      f(node);
+    }
+  }
+}

--- a/src/tsconfig.esbuild.json
+++ b/src/tsconfig.esbuild.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.content-all.json",
-  "compilerOptions": {
-    // GlobTrie.js throws an error when "use strict"
-    // > Uncaught ReferenceError: GlobTrie is not defined
-    "strict": false
-  }
-}

--- a/src/types/glob-trie.d.ts
+++ b/src/types/glob-trie.d.ts
@@ -1,7 +1,0 @@
-module "glob-trie.js" {
-  export default class GlobTrie<T> {
-    constructor();
-    add(pattern: string, value: T): void;
-    collect(s: string): string[];
-  }
-}

--- a/test/lib/glob-trie.test.ts
+++ b/test/lib/glob-trie.test.ts
@@ -1,0 +1,231 @@
+// Ported from the original `glob-trie.js` test suite
+// (https://github.com/rbranson/glob-trie.js/blob/master/test.js).
+// The `remove` / `nodeCount` based assertions are omitted because those
+// methods are not part of the API used by knavi.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import GlobTrie from "../../src/lib/glob-trie";
+
+const sorted = (a: string[]) => [...a].sort();
+
+void describe("GlobTrie", () => {
+  void describe("url patterns", () => {
+    const urlTrie = new GlobTrie<string>();
+
+    urlTrie.add("*", "*");
+    urlTrie.add("*://example.com/", "*://example.com/");
+    urlTrie.add("http://*", "http://*");
+    urlTrie.add("http://*.example.com/", "http://*.example.com/");
+    urlTrie.add("http://*example.com/", "http://*example.com/");
+    urlTrie.add("http://example.com/*", "http://example.com/*");
+    urlTrie.add("http://example.com/*/foo", "http://example.com/*/foo");
+    urlTrie.add("http://example.com/*/bar", "http://example.com/*/bar");
+    urlTrie.add("http://?x?mple.com/*", "http://?x?mple.com/*");
+    urlTrie.add("http://*example.????*", "http://*example.????*");
+    urlTrie.add("http://*example.???*", "http://*example.???*");
+    urlTrie.add("http://*example.??*", "http://*example.??*");
+    urlTrie.add("http://example.com/\\?q=*", "http://example.com/\\?q=*");
+    urlTrie.add("http://example.com/\\q", "http://example.com/\\q");
+    urlTrie.add("http://example.com/\\", "http://example.com/\\");
+
+    void test("http://", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://")),
+        sorted(["*", "http://*"]),
+      );
+    });
+
+    void test("http://www.example.com/", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://www.example.com/")),
+        sorted([
+          "*",
+          "http://*",
+          "http://*.example.com/",
+          "http://*example.com/",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+
+    void test("http://example.com/", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://example.com/")),
+        sorted([
+          "*",
+          "*://example.com/",
+          "http://*",
+          "http://*example.com/",
+          "http://?x?mple.com/*",
+          "http://example.com/*",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+
+    void test("http://example.com/page.html", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://example.com/page.html")),
+        sorted([
+          "*",
+          "http://*",
+          "http://example.com/*",
+          "http://?x?mple.com/*",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+
+    void test("http://www.nodejs.org/", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://www.nodejs.org/")),
+        sorted(["*", "http://*"]),
+      );
+    });
+
+    void test("ftp://example.com/", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("ftp://example.com/")),
+        sorted(["*", "*://example.com/"]),
+      );
+    });
+
+    void test("http://example.com/?q=books", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://example.com/?q=books")),
+        sorted([
+          "*",
+          "http://*",
+          "http://?x?mple.com/*",
+          "http://example.com/*",
+          "http://example.com/\\?q=*",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+
+    void test("http://example.com/bar/foo", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://example.com/bar/foo")),
+        sorted([
+          "*",
+          "http://*",
+          "http://?x?mple.com/*",
+          "http://example.com/*",
+          "http://example.com/*/foo",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+
+    void test("http://example.com/bar", () => {
+      assert.deepStrictEqual(
+        sorted(urlTrie.collect("http://example.com/bar")),
+        sorted([
+          "*",
+          "http://*",
+          "http://?x?mple.com/*",
+          "http://example.com/*",
+          "http://*example.????*",
+          "http://*example.???*",
+          "http://*example.??*",
+        ]),
+      );
+    });
+  });
+
+  void describe("character classes", () => {
+    const classTrie = new GlobTrie<string>();
+
+    classTrie.add("[a-zA-Z0-9]", "[a-zA-Z0-9]");
+    classTrie.add("[0-9]*", "[0-9]*");
+    classTrie.add("*[0-9]", "*[0-9]");
+    classTrie.add("*[0-9]*", "*[0-9]*");
+    classTrie.add("[\\[\\]\\?\\(\\)\\.\\*\\\\]", "[\\[\\]\\?\\(\\)\\.\\*\\\\]");
+    classTrie.add("[^0-9]", "[^0-9]");
+
+    void test("no match", () => {
+      assert.deepStrictEqual(
+        classTrie.collect("This won't match anything"),
+        [],
+      );
+    });
+
+    void test("0", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("0")),
+        sorted(["[a-zA-Z0-9]", "[0-9]*", "*[0-9]", "*[0-9]*"]),
+      );
+    });
+
+    void test("1", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("1")),
+        sorted(["[a-zA-Z0-9]", "[0-9]*", "*[0-9]", "*[0-9]*"]),
+      );
+    });
+
+    void test("100", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("100")),
+        sorted([
+          "[0-9]*",
+          "*[0-9]",
+          "*[0-9]*",
+          "*[0-9]*",
+          "*[0-9]*", // matched once per character, as in the original
+        ]),
+      );
+    });
+
+    void test("abc1", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("abc1")),
+        sorted(["*[0-9]", "*[0-9]*"]),
+      );
+    });
+
+    void test("1abc", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("1abc")),
+        sorted(["[0-9]*", "*[0-9]*"]),
+      );
+    });
+
+    void test("a", () => {
+      assert.deepStrictEqual(
+        sorted(classTrie.collect("a")),
+        sorted(["[a-zA-Z0-9]", "[^0-9]"]),
+      );
+    });
+
+    // Every escaped metacharacter
+    for (const c of ["[", "]", "(", ")", ".", "?", "\\"]) {
+      void test(`escaped ${c}`, () => {
+        assert.deepStrictEqual(
+          sorted(classTrie.collect(c)),
+          sorted(["[\\[\\]\\?\\(\\)\\.\\*\\\\]", "[^0-9]"]),
+        );
+      });
+    }
+  });
+
+  void describe("regression", () => {
+    void test("does not match a longer pattern against a shorter string", () => {
+      const stupidBugTrie = new GlobTrie<string>();
+      stupidBugTrie.add("[0-9][a-z]", "[0-9][a-z]");
+      assert.notStrictEqual(stupidBugTrie.collect("00")[0], "[0-9][a-z]");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the unmaintained `glob-trie.js` (v0.2.1) dependency with an in-tree, strict-mode-compliant TypeScript implementation, allowing the `strict: false` workaround to be removed from the content scripts build.

`glob-trie.js` relied on an implicit global assignment (`module.exports = GlobTrie = ...`) that throws `ReferenceError: GlobTrie is not defined` in strict mode, which is why `src/tsconfig.esbuild.json` disabled strict checks for the entire content scripts build.

## Changes

- Add `src/lib/glob-trie.ts` — a generic, strict TypeScript port of the original `add`/`collect` trie algorithm.
- Point `src/lib/blacklist.ts` and `src/lib/additional-selectors.ts` at the new module.
- Remove the `glob-trie.js` dependency, its `src/types/glob-trie.d.ts` stub, and `src/tsconfig.esbuild.json`; `scripts/build.ts` now uses `tsconfig.content-all.json` directly.
- Add `test/lib/glob-trie.test.ts`, ported from the original `glob-trie.js` `test.js`, to confirm behavioral equivalence (the `remove`/`nodeCount` assertions are omitted since those methods are unused by knavi).

## Verification

`npm run fix && npm run lint && npm run test` all pass (41 tests). `npm run build` succeeds.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)