### PR TITLE
Fix manifest.json: remove deprecated author field, remove *.js.map WAR, add minimum_chrome_version

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -78,7 +78,7 @@ export async function build({
     bundle: true,
     sourcemap: true,
     minify,
-    target: "chrome100",
+    target: "chrome114",
     tsconfig: path.join(SRC, "tsconfig.content-all.json"),
     pure: [
       "console.debug",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -6,7 +6,7 @@ export default function manifest(pkg: Pkg): chrome.runtime.ManifestV3 {
     name: pkg.name,
     version: pkg.version,
     description: pkg.description,
-    author: { email: pkg.author },
+    minimum_chrome_version: "114",
     icons: {
       16: "icon16.png",
       48: "icon48.png",
@@ -47,11 +47,5 @@ export default function manifest(pkg: Pkg): chrome.runtime.ManifestV3 {
     },
     permissions: ["storage"],
     host_permissions: ["<all_urls>"],
-    web_accessible_resources: [
-      {
-        matches: ["<all_urls>"],
-        resources: ["*.js.map"],
-      },
-    ],
   };
 }


### PR DESCRIPTION
## Summary

- **#67** — Remove the `author` field entirely. It was deprecated and **silently ignored** by Chrome and the Chrome Web Store as of February 2024; the field is no longer part of the MV3 spec.
- **#64** — Remove the `web_accessible_resources` entry for `*.js.map`. Source maps load fine in DevTools for an unpacked build without being web-accessible; exposing them lets any page fingerprint the extension via `fetch()`.
- **#61** — Add `minimum_chrome_version: "114"` to block installation on Chrome 100–113 where `showPopover()` is unavailable. Align esbuild `target` to `chrome114` to match.

## Test plan

- [x] `npm run fix && npm run lint && npm run test` passes (all 50 tests green, no lint errors)
- [x] Build the extension (`npm run build`) and verify `manifest.json` contains `minimum_chrome_version`, no `web_accessible_resources`, and no `author` field

Closes #61, #64, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)