### PR TITLE
Fix TypeError crash and Error cause misuse in sendToRuntime/sendToTab

### DIFF
--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -203,7 +203,11 @@ export async function sendToRuntime<T extends keyof Messages>(
   const r = await chrome.runtime.sendMessage<Message<T>, SendResponseArg<T>>(
     message(type, payload),
   );
-  if ("error" in r) throw Error(r.error.message, r.error);
+  if (r == null)
+    throw Error(
+      `No response for ${type}: receiver missing or handler not registered`,
+    );
+  if ("error" in r) throw Error(r.error.message, { cause: r.error });
   return r.response;
 }
 
@@ -218,6 +222,10 @@ export async function sendToTab<T extends keyof Messages>(
     message(type, payload),
     options,
   );
-  if ("error" in r) throw Error(r.error.message, r.error);
+  if (r == null)
+    throw Error(
+      `No response for ${type}: receiver missing or handler not registered`,
+    );
+  if ("error" in r) throw Error(r.error.message, { cause: r.error });
   return r.response;
 }


### PR DESCRIPTION
## Summary

- Guard against `undefined` response in `sendToRuntime` and `sendToTab`: when no handler is registered, `chrome.runtime.sendMessage` / `chrome.tabs.sendMessage` resolves with `undefined`, causing `"error" in r` to throw `TypeError`. Added a `r == null` check that throws a descriptive error instead.
- Fix `Error` cause option: changed `throw Error(r.error.message, r.error)` → `throw Error(r.error.message, { cause: r.error })` so the cause is correctly attached via the options object.

Fixes #62

## Test plan

- [ ] `npm run fix && npm run lint && npm run test` passes (verified locally)
- [ ] Manual: triggering a message with no registered handler now throws a descriptive `Error` instead of a `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)