### PR TITLE
Treat showPicker() as best-effort to avoid NotAllowedError in cross-frame actions

### DIFF
--- a/src/content-all/action-handlers.ts
+++ b/src/content-all/action-handlers.ts
@@ -157,7 +157,11 @@ HANDLERS.push({
   async handle(target: HTMLInputElement) {
     target.focus();
     await nextAnimationFrame();
-    target.showPicker();
+    try {
+      target.showPicker();
+    } catch {
+      // NotAllowedError: no user activation in this frame; focus is enough.
+    }
   },
 });
 
@@ -205,7 +209,11 @@ HANDLERS.push({
     target.focus();
     await nextAnimationFrame();
     if ("showPicker" in target && typeof target.showPicker === "function") {
-      target.showPicker();
+      try {
+        target.showPicker();
+      } catch {
+        // NotAllowedError: no user activation in this frame; focus is enough.
+      }
     }
   },
 });


### PR DESCRIPTION
## Summary

- Wraps both `HTMLInputElement` and `HTMLSelectElement` `showPicker()` calls in `try/catch` so that `NotAllowedError` (thrown when user activation is absent in the target frame) is silently ignored
- `focus()` is still called before `showPicker()`, so the element is always focused even if the picker cannot be opened
- The `HTMLSelectElement` handler already feature-detected `showPicker` before calling it; the new try/catch is added inside that existing guard

## Test plan

- [ ] `npm run fix && npm run lint && npm run test` passes (verified locally)
- [ ] Manual test: trigger a hint on an `<input type="date">` inside a cross-origin iframe — no console error, element receives focus

Closes #69