### PR TITLE
Replace non-null assertions on sender with explicit guards

### DIFF
--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,8 +1,9 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
+import { requireTabId } from "../lib/sender-guards";
 
 export const router = Router.newInstance().addAll(
   ["AttachHints", "RemoveHints", "HitHint"],
   (type) => async (msg, sender) => {
-    return await sendToTab(sender.tab!.id!, type, msg, { frameId: 0 });
+    return await sendToTab(requireTabId(sender), type, msg, { frameId: 0 });
   },
 );

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -1,16 +1,17 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
+import { requireFrameId, requireTabId } from "../lib/sender-guards";
 
 export const router = Router.newInstance()
-  .add("GetFrameId", (_, sender) => sender.frameId!)
+  .add("GetFrameId", (_, sender) => requireFrameId(sender))
 
   .add("ResponseRectsFragment", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ResponseRectsFragment", message, {
+    await sendToTab(requireTabId(sender), "ResponseRectsFragment", message, {
       frameId: 0,
     });
   })
 
   .add("ExecuteAction", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ExecuteAction", message, {
+    await sendToTab(requireTabId(sender), "ExecuteAction", message, {
       frameId: message.id.frameId,
     });
   });

--- a/src/lib/sender-guards.ts
+++ b/src/lib/sender-guards.ts
@@ -1,0 +1,17 @@
+export function requireTabId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.tab?.id;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (sender.tab.id is missing)",
+    );
+  return id;
+}
+
+export function requireFrameId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.frameId;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (sender.frameId is missing)",
+    );
+  return id;
+}


### PR DESCRIPTION
## Summary

- Add `requireTabId` and `requireFrameId` helpers in `src/lib/sender-guards.ts` that throw a descriptive `Error` when the expected sender field is absent.
- Replace `sender.tab!.id!` / `sender.frameId!` non-null assertions in `src/background/rect-aggregator.ts` and `src/background/hinter.ts` with calls to these helpers.

Sending one of these message types from a context without a tab (e.g. the options page) now produces a clear error message instead of a silent `TypeError`.

Closes #68

## Test plan

- [x] `npm run fix && npm run lint && npm run test` passes (50/50 tests green, no lint errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)