### PR TITLE
Filter and debounce chrome.storage.onChanged in content-all

### DIFF
--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -31,8 +31,22 @@ async function setup() {
 }
 setup().catch(printError);
 
-chrome.storage.onChanged.addListener(() => {
-  setup().catch(printError);
+const SETUP_KEYS: ReadonlySet<string> = new Set([
+  "magicKey",
+  "blurKey",
+  "hints",
+  "stickyKey",
+  "actionKey",
+  "cancelKey",
+]);
+
+let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+chrome.storage.onChanged.addListener((changes) => {
+  if (!Object.keys(changes).some((k) => SETUP_KEYS.has(k))) return;
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    setup().catch(printError);
+  }, 200);
 });
 
 chrome.runtime.onMessage.addListener(


### PR DESCRIPTION
## Summary

- Add a `SETUP_KEYS` set (`magicKey`, `blurKey`, `hints`, `stickyKey`, `actionKey`, `cancelKey`) to the `chrome.storage.onChanged` listener in `src/content-all.ts`
- Return early when none of the changed keys are in `SETUP_KEYS`, preventing unnecessary re-fetches from storage-only changes like blacklist edits or area switches
- Add a 200 ms debounce so rapid bursts of changes (e.g. options-page saves) are coalesced into a single `setup()` call instead of spawning one per frame per change event

## Test plan

- [ ] `npm run fix && npm run lint && npm run test` passes (all 50 tests green)
- [ ] Manually verify that changing a relevant setting (e.g. `magicKey`) in the options page still triggers setup correctly
- [ ] Verify that changing an unrelated setting (e.g. `blackList`) does **not** trigger setup in content-all frames

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)