### PR TITLE
Fix HinterClient rollback on send failure and HintView.remove() when container is detached

### DIFF
--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -207,10 +207,12 @@ export class HintView {
   remove() {
     if (!this.hints) throw Error("Illegal state");
 
-    document.body.removeChild(this.container);
-    for (const e of flatMap(this.hints.all(), (h) => h.hints))
-      this.root.removeChild(e);
-    this.hints = null;
+    try {
+      this.container.remove();
+      for (const e of flatMap(this.hints.all(), (h) => h.hints)) e.remove();
+    } finally {
+      this.hints = null;
+    }
   }
 }
 

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -15,7 +15,12 @@ export default class HinterClient {
   async attachHints() {
     if (this.hinting) throw Error("Illegal state");
     this.hinting = true;
-    await sendToRuntime("AttachHints", undefined);
+    try {
+      await sendToRuntime("AttachHints", undefined);
+    } catch (e) {
+      this.hinting = false;
+      throw e;
+    }
   }
 
   async hitHint(key: SingleLetter) {


### PR DESCRIPTION
## Summary

- **HinterClient.attachHints()**: Roll back the `hinting` flag inside a `try/catch` if `sendToRuntime` throws. Previously, a send failure left `hinting = true` permanently until the next keyup, causing all subsequent keydowns to be misrouted as hint input.
- **HintView.remove()**: Replace `document.body.removeChild(this.container)` with `this.container.remove()`, which is a no-op when the element is already detached (e.g. after an SPA replaces `<body>`). Wrap the whole removal in `try/finally` so `this.hints` is always cleared — preventing the permanent "Illegal state" error on every future `start()`.

Fixes #66

## Test plan

- [ ] `npm run fix && npm run lint && npm run test` passes (verified locally — 50/50 tests green)
- [ ] Manual: trigger a hint session in a tab where the content-root is unreachable; confirm a second hint session can be started without reload
- [ ] Manual: navigate an SPA that replaces `<body>`, dismiss hints, confirm hint session can be started again

🤖 Generated with [Claude Code](https://claude.com/claude-code)