### PR TITLE
Replace non-null assertions on sender with guard functions (fixes #68)

### DIFF
--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,8 +1,17 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
 
+function requireTabId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.tab?.id;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (no sender.tab.id)",
+    );
+  return id;
+}
+
 export const router = Router.newInstance().addAll(
   ["AttachHints", "RemoveHints", "HitHint"],
   (type) => async (msg, sender) => {
-    return await sendToTab(sender.tab!.id!, type, msg, { frameId: 0 });
+    return await sendToTab(requireTabId(sender), type, msg, { frameId: 0 });
   },
 );

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -1,16 +1,34 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
 
+function requireTabId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.tab?.id;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (no sender.tab.id)",
+    );
+  return id;
+}
+
+function requireFrameId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.frameId;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (no sender.frameId)",
+    );
+  return id;
+}
+
 export const router = Router.newInstance()
-  .add("GetFrameId", (_, sender) => sender.frameId!)
+  .add("GetFrameId", (_, sender) => requireFrameId(sender))
 
   .add("ResponseRectsFragment", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ResponseRectsFragment", message, {
+    await sendToTab(requireTabId(sender), "ResponseRectsFragment", message, {
       frameId: 0,
     });
   })
 
   .add("ExecuteAction", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ExecuteAction", message, {
+    await sendToTab(requireTabId(sender), "ExecuteAction", message, {
       frameId: message.id.frameId,
     });
   });


### PR DESCRIPTION
## Summary

- Introduce `requireTabId(sender)` in `src/background/rect-aggregator.ts` and `src/background/hinter.ts` that throws a clear `Error` when `sender.tab?.id` is absent, replacing the silent `sender.tab!.id!` non-null assertions.
- Introduce `requireFrameId(sender)` in `src/background/rect-aggregator.ts` that throws a clear `Error` when `sender.frameId` is absent, replacing the silent `sender.frameId!` assertion.

## Test plan

- [ ] `npm run fix && npm run lint && npm run test` passes (verified locally)
- [ ] Manually confirm that normal hint-flow still works end-to-end (messages from content scripts carry valid `tab.id` and `frameId`, so the guards never throw in practice)

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)