### PR TITLE
Fix: wrap showPicker() in try/catch to handle NotAllowedError in cross-frame activation

### DIFF
--- a/src/content-all/action-handlers.ts
+++ b/src/content-all/action-handlers.ts
@@ -157,7 +157,11 @@ HANDLERS.push({
   async handle(target: HTMLInputElement) {
     target.focus();
     await nextAnimationFrame();
-    target.showPicker();
+    try {
+      target.showPicker();
+    } catch {
+      // NotAllowedError when the frame lacks user activation; focus is enough.
+    }
   },
 });
 
@@ -205,7 +209,11 @@ HANDLERS.push({
     target.focus();
     await nextAnimationFrame();
     if ("showPicker" in target && typeof target.showPicker === "function") {
-      target.showPicker();
+      try {
+        target.showPicker();
+      } catch {
+        // NotAllowedError when the frame lacks user activation; focus is enough.
+      }
     }
   },
 });


### PR DESCRIPTION
## Summary

- `showPicker()` requires transient user activation in the *target* frame. When knavi executes an action cross-frame via `ExecuteAction`, the target frame has no user activation and `showPicker()` throws `NotAllowedError`.
- Wrap both the `<input>` and `<select>` `showPicker()` calls in `try/catch`, treating the picker as best-effort — the element is already focused, which is sufficient.
- Consistent with the `isEditable` guard added in #60.

## Test plan

- [ ] Verify `npm run fix && npm run lint && npm run test` passes (done locally).
- [ ] Manually confirm picker still opens for same-frame hints (date, color, select inputs).
- [ ] Confirm no error is logged when activating an input in a cross-origin iframe.

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)