### PR TITLE
Replace non-null assertions on sender.tab!.id! / sender.frameId! with explicit guards

### DIFF
--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,8 +1,9 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
+import { requireTabId } from "./sender-guards";
 
 export const router = Router.newInstance().addAll(
   ["AttachHints", "RemoveHints", "HitHint"],
   (type) => async (msg, sender) => {
-    return await sendToTab(sender.tab!.id!, type, msg, { frameId: 0 });
+    return await sendToTab(requireTabId(sender), type, msg, { frameId: 0 });
   },
 );

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -1,16 +1,17 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
+import { requireFrameId, requireTabId } from "./sender-guards";
 
 export const router = Router.newInstance()
-  .add("GetFrameId", (_, sender) => sender.frameId!)
+  .add("GetFrameId", (_, sender) => requireFrameId(sender))
 
   .add("ResponseRectsFragment", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ResponseRectsFragment", message, {
+    await sendToTab(requireTabId(sender), "ResponseRectsFragment", message, {
       frameId: 0,
     });
   })
 
   .add("ExecuteAction", async (message, sender) => {
-    await sendToTab(sender.tab!.id!, "ExecuteAction", message, {
+    await sendToTab(requireTabId(sender), "ExecuteAction", message, {
       frameId: message.id.frameId,
     });
   });

--- a/src/background/sender-guards.ts
+++ b/src/background/sender-guards.ts
@@ -1,0 +1,17 @@
+export function requireTabId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.tab?.id;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (no sender.tab.id)",
+    );
+  return id;
+}
+
+export function requireFrameId(sender: chrome.runtime.MessageSender): number {
+  const id = sender.frameId;
+  if (id == null)
+    throw Error(
+      "This message must be sent from a content script (no sender.frameId)",
+    );
+  return id;
+}


### PR DESCRIPTION
## Summary

- Add `requireTabId` and `requireFrameId` helper functions in `src/background/sender-guards.ts` that throw a descriptive `Error` when the sender is missing the expected field.
- Replace all `!`-assertions in `src/background/rect-aggregator.ts` (3 sites) and `src/background/hinter.ts` (1 site) with calls to these helpers.
- Messages sent from a non-content-script context (e.g. options page, future code) now fail with a clear, actionable error message instead of a silent `TypeError: Cannot read properties of undefined`.

## Test plan

- [x] `npm run fix && npm run lint && npm run test` — all 70 tests pass, lint clean.
- [x] TypeScript builds without errors (`lint:tsc`).

Closes #68