### PR TITLE
Fix stale blacklist after SPA navigation (history.pushState)

### DIFF
--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -63,6 +63,13 @@ chrome.storage.onChanged.addListener((changes) => {
   });
 });
 
+window.navigation?.addEventListener("navigatesuccess", () => {
+  settingsClient
+    .matchBlacklist(location.href)
+    .then((matched) => keyboardHandler.updateBlacklist(matched))
+    .catch(printError);
+});
+
 chrome.runtime.onMessage.addListener(
   ChromeMessageRouter.newInstance()
     .add("ExecuteAction", ({ id, options }) =>

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -50,6 +50,10 @@ export class KeyboardHandlerContentAll {
     this.matchedBlacklist = matchedBlacklist;
   }
 
+  updateBlacklist(matchedBlacklist: string[]) {
+    this.matchedBlacklist = matchedBlacklist;
+  }
+
   // Reset the held-key history of every matcher.
   private resetMatchers() {
     this.hitMatcher?.reset();


### PR DESCRIPTION
## Summary

- `KeyboardHandlerContentAll.setup()` evaluated `matchedBlacklist` only once at startup (and on `chrome.storage.onChanged`), so SPA navigations via `history.pushState` left the blacklist stale.
- Added `updateBlacklist(matched: string[])` to `KeyboardHandlerContentAll` so the blacklist can be updated independently of the full settings re-load.
- In `content-all.ts`, registered a `window.navigation?.addEventListener("navigatesuccess", ...)` listener (with the optional-chaining feature check for browsers without the Navigation API) that re-runs `settingsClient.matchBlacklist(location.href)` and calls `keyboardHandler.updateBlacklist()` on every successful SPA navigation.

The change is consistent with the debounce/storage-filter refactor merged in #70.

Closes #63

## Test plan

- [ ] Unit tests pass (`npm run test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Manual: on an SPA (e.g. GitHub's Issues list → a specific issue), navigate between a blacklisted URL and a non-blacklisted URL via the browser's back/forward buttons or in-page links; confirm knavi enables/disables correctly after each navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)