### PR TITLE
Fix hinting state stuck on send failure and detached container

### DIFF
--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -206,11 +206,12 @@ export class HintView {
 
   remove() {
     if (!this.hints) throw Error("Illegal state");
-
-    document.body.removeChild(this.container);
-    for (const e of flatMap(this.hints.all(), (h) => h.hints))
-      this.root.removeChild(e);
-    this.hints = null;
+    try {
+      this.container.remove();
+      for (const e of flatMap(this.hints.all(), (h) => h.hints)) e.remove();
+    } finally {
+      this.hints = null;
+    }
   }
 }
 

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -15,7 +15,12 @@ export default class HinterClient {
   async attachHints() {
     if (this.hinting) throw Error("Illegal state");
     this.hinting = true;
-    await sendToRuntime("AttachHints", undefined);
+    try {
+      await sendToRuntime("AttachHints", undefined);
+    } catch (e) {
+      this.hinting = false;
+      throw e;
+    }
   }
 
   async hitHint(key: SingleLetter) {


### PR DESCRIPTION
## Summary

Fixes #66 — two robustness issues that could permanently break hinting in a tab:

- **`HinterClient.attachHints()`** (`src/lib/hinter-client.ts`): `hinting` was set to `true` before `await sendToRuntime(...)`. If the send threw (e.g. content-root not reachable), the flag stayed `true` and all subsequent keydowns were treated as hinting input. Fixed by wrapping the send in `try/catch` and resetting `hinting = false` on failure.

- **`HintView.remove()`** (`src/content-root/hinter-view.ts`): `document.body.removeChild(this.container)` threw when the page had replaced `<body>` (common in SPAs), leaving `this.hints` non-null and causing every later `start()` to throw `Illegal state`. Fixed by using `element.remove()` (no-op when already detached) and moving `this.hints = null` into a `finally` block so state is always cleared.

## Test plan

- [x] `npm run fix && npm run lint && npm run test` — 70/70 pass, no lint errors
- [ ] Manual: trigger a hint session on a SPA page that replaces `<body>`, confirm hints can be reopened after removal
- [ ] Manual: simulate a failed `AttachHints` send (e.g. block the content-root), confirm subsequent hint sessions work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)