### PR TITLE
Simplify message() void payload handling and other unnecessary complexity

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -12,11 +12,16 @@ globalThis.KNAVI_FILE = "background";
 migration.init(libSettings);
 actionIcon.init();
 
+import { Router } from "./lib/chrome-messages";
+
 chrome.runtime.onMessage.addListener(
-  rectAggregator.router
-    .merge(hinter.router)
-    .merge(blurer.router)
-    .merge(frameRegistry.router)
-    .merge(settings.router)
+  Router.newInstance()
+    .mergeAll(
+      rectAggregator.router,
+      hinter.router,
+      blurer.router,
+      frameRegistry.router,
+      settings.router,
+    )
     .buildListener(),
 );

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,16 +12,11 @@ globalThis.KNAVI_FILE = "background";
 migration.init(libSettings);
 actionIcon.init();
 
-import { Router } from "./lib/chrome-messages";
-
 chrome.runtime.onMessage.addListener(
-  Router.newInstance()
-    .mergeAll(
-      rectAggregator.router,
-      hinter.router,
-      blurer.router,
-      frameRegistry.router,
-      settings.router,
-    )
+  rectAggregator.router
+    .merge(hinter.router)
+    .merge(blurer.router)
+    .merge(frameRegistry.router)
+    .merge(settings.router)
     .buildListener(),
 );

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -1,4 +1,4 @@
-import { Router, sendToTab } from "../lib/chrome-messages";
+import { Router, sendToTab, type Messages } from "../lib/chrome-messages";
 import { requireTabId } from "./sender-guards";
 import { getAllFrameIds } from "./frame-registry";
 import { Rect } from "../lib/rects";
@@ -53,7 +53,7 @@ interface FrameOffset {
   y: number;
 }
 
-type FrameResponse = Awaited<ReturnType<typeof sendToTab<"FetchFrameRects">>>;
+type FrameResponse = Messages["FetchFrameRects"]["response"];
 type ClipRect = RectJSON<"actual-viewport", "root-viewport">;
 
 function composeFrame(

--- a/src/content-root/blurer.ts
+++ b/src/content-root/blurer.ts
@@ -1,6 +1,5 @@
 import BlurView from "./blurer-view";
 import { transformBlurRect } from "../dom/blur-rect";
-import { Rect } from "../dom/rects";
 
 if (parent !== window)
   throw Error("This script must be loaded in the root frame.");
@@ -20,7 +19,13 @@ export class BlurerContentRoot {
       return;
     }
 
-    const rect = this.toRootViewport(childFrameId, rectJson);
+    // In root frame, layout-viewport === root-viewport.
+    const rect = transformBlurRect(
+      this.iframeMap,
+      childFrameId,
+      rectJson,
+      "root-viewport",
+    );
     if (!rect) return;
 
     const activeElement = document.activeElement;
@@ -28,18 +33,5 @@ export class BlurerContentRoot {
     (activeElement.blur as () => void)();
 
     this.view.blur(rect);
-  }
-
-  // In root frame, layout-viewport === root-viewport.
-  private toRootViewport(
-    childFrameId: number,
-    rectJson: RectJSON<"element-border", "layout-viewport">,
-  ): Rect<"element-border", "root-viewport"> | null {
-    return transformBlurRect(
-      this.iframeMap,
-      childFrameId,
-      rectJson,
-      "root-viewport",
-    );
   }
 }

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -163,16 +163,6 @@ export class Router<
     return this;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- merging heterogeneous routers
-  mergeAll(...routers: Router<any>[]): Router<any> {
-    for (const router of routers) {
-      for (const [type, handler] of router.handlers) {
-        this.handlers.set(type, handler);
-      }
-    }
-    return this;
-  }
-
   // Returns true if the message is handled asynchronously.
   // See https://developer.chrome.com/docs/extensions/mv3/messaging/#simple.
   private route<T extends keyof Messages>(

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -1,7 +1,7 @@
 import type { SingleLetter } from "./strings";
 
 // TODO separate by the handler (background, content, popup, etc)
-interface Messages {
+export interface Messages {
   // Settings
   GetSettings: {
     payload: { names: (keyof Settings)[] };
@@ -112,8 +112,9 @@ function type<T extends keyof Messages>(m: Message<T>): T {
 
 function message<T extends keyof Messages>(
   type: T,
-  payload: MessagePayload<T>,
+  payload?: MessagePayload<T>,
 ): Message<T> {
+  if (payload === undefined) return { "@type": type } as Message<T>;
   return { "@type": type, ...payload };
 }
 
@@ -158,6 +159,16 @@ export class Router<
   ): Router<Exclude<RegisteredTypes | T, void>> {
     for (const [type, handler] of router.handlers) {
       this.handlers.set(type, handler);
+    }
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- merging heterogeneous routers
+  mergeAll(...routers: Router<any>[]): Router<any> {
+    for (const router of routers) {
+      for (const [type, handler] of router.handlers) {
+        this.handlers.set(type, handler);
+      }
     }
     return this;
   }
@@ -226,7 +237,7 @@ export async function sendToRuntime<T extends keyof Messages>(
   payload?: MessagePayload<T>,
 ): Promise<Response<T>> {
   const r = await chrome.runtime.sendMessage<Message<T>, SendResponseArg<T>>(
-    message(type, payload ?? ({} as MessagePayload<T>)),
+    message(type, payload),
   );
   if (r == null)
     throw Error(

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -163,6 +163,12 @@ export class Router<
     return this;
   }
 
+  // Do NOT add a mergeAll() convenience method that takes variadic Router
+  // arguments.  Router generics are invariant, so heterogeneous Router<>s
+  // cannot be collected into a tuple without resorting to Router<any>, which
+  // defeats compile-time duplicate-detection.  Use chained .merge() instead:
+  //   r.merge(a).merge(b).merge(c).buildListener()
+
   // Returns true if the message is handled asynchronously.
   // See https://developer.chrome.com/docs/extensions/mv3/messaging/#simple.
   private route<T extends keyof Messages>(


### PR DESCRIPTION


- Fix message() to accept optional payload, removing the unsafe  cast in sendToRuntime that forced void payloads to
- Export Messages interface and use it directly for FrameResponse type instead of the opaque Awaited<ReturnType<typeof ...>> chain
- Inline toRootViewport into handleBlurRelay in content-root/blurer.ts