### PR TITLE
Restore incremental hint rendering: stream rect fragments per frame

### DIFF
--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -8,38 +8,85 @@ export const router = Router.newInstance()
     const tabId = requireTabId(sender);
     const frameIds = getAllFrameIds(tabId);
 
-    const responses = await Promise.allSettled(
-      frameIds.map(async (frameId) => {
-        const response = await sendToTab(
-          tabId,
-          "FetchFrameRects",
-          { requestId },
-          { frameId },
+    // Each frame's local rects can only be placed in root-viewport coordinates
+    // once the cumulative offset/clip of its whole ancestor chain is known. We
+    // therefore fan out to every frame in parallel and, as each response
+    // arrives, emit a ResponseRectsFragment for any frame whose placement and
+    // own data are both available — streaming hints to the root frame instead
+    // of waiting for the slowest frame.
+    const frameData = new Map<number, FrameResponse>();
+    const placements = new Map<number, FramePlacement>([
+      [0, { offset: { x: 0, y: 0 }, clip: null }],
+    ]);
+    const emitted = new Set<number>();
+    const sends: Promise<void>[] = [];
+
+    const emitFrame = (frameId: number): void => {
+      if (emitted.has(frameId)) return;
+      const placement = placements.get(frameId);
+      const data = frameData.get(frameId);
+      if (!placement || !data) return; // wait for ancestors or own response
+
+      emitted.add(frameId);
+
+      const rects = composeElements(frameId, data, placement);
+      if (rects.length > 0) {
+        sends.push(
+          sendToTab(
+            tabId,
+            "ResponseRectsFragment",
+            { requestId, rects },
+            { frameId: 0 },
+          ),
         );
-        return { frameId, response };
+      }
+
+      // This frame's data carries the geometry of its direct children, so their
+      // placements become computable now; try to emit any already-received ones.
+      for (const child of data.childIframes) {
+        placements.set(child.childFrameId, childPlacement(placement, child));
+        emitFrame(child.childFrameId);
+      }
+    };
+
+    await Promise.allSettled(
+      frameIds.map(async (frameId) => {
+        try {
+          frameData.set(
+            frameId,
+            await sendToTab(
+              tabId,
+              "FetchFrameRects",
+              { requestId },
+              { frameId },
+            ),
+          );
+          emitFrame(frameId);
+        } catch (e) {
+          console.debug("FetchFrameRects failed:", e);
+        }
       }),
     );
 
-    const frameData = new Map<number, FrameResponse>();
-    for (const result of responses) {
-      if (result.status === "fulfilled") {
-        frameData.set(result.value.frameId, result.value.response);
-      } else {
-        console.debug("FetchFrameRects failed:", result.reason);
-      }
+    if (!frameData.has(0)) {
+      console.warn(
+        "Root frame did not respond to FetchFrameRects; no rects will be composed.",
+      );
     }
 
-    const composed = composeFrame(0, { x: 0, y: 0 }, null, frameData);
-
-    // Always send ResponseRectsFragment (even when empty) so that the
-    // root frame's aggregate() generator receives at least one message
-    // and does not hang indefinitely.
-    await sendToTab(
-      tabId,
-      "ResponseRectsFragment",
-      { requestId, rects: composed },
-      { frameId: 0 },
-    );
+    // Guarantee at least one message so the root frame's aggregate() generator
+    // does not hang when no frame produced any rect.
+    if (sends.length === 0) {
+      sends.push(
+        sendToTab(
+          tabId,
+          "ResponseRectsFragment",
+          { requestId, rects: [] },
+          { frameId: 0 },
+        ),
+      );
+    }
+    await Promise.allSettled(sends);
   })
 
   .add("ExecuteAction", async (message, sender) => {
@@ -53,27 +100,23 @@ interface FrameOffset {
   y: number;
 }
 
+interface FramePlacement {
+  offset: FrameOffset;
+  clip: ClipRect | null;
+}
+
 type FrameResponse = Messages["FetchFrameRects"]["response"];
+type ChildIframe = FrameResponse["childIframes"][number];
 type ClipRect = RectJSON<"actual-viewport", "root-viewport">;
 
-function composeFrame(
+// Translate a frame's local element rects into root-viewport coordinates and
+// drop those clipped away by the frame's visible viewport chain.
+function composeElements(
   frameId: number,
-  offset: FrameOffset,
-  clip: ClipRect | null,
-  frameData: Map<number, FrameResponse>,
+  data: FrameResponse,
+  { offset, clip }: FramePlacement,
 ): ElementRects[] {
-  const data = frameData.get(frameId);
-  if (!data) {
-    if (frameId === 0) {
-      console.warn(
-        "Root frame did not respond to FetchFrameRects; no rects will be composed.",
-      );
-    }
-    return [];
-  }
-
   const result: ElementRects[] = [];
-
   for (const elem of data.elements) {
     const translatedRects = elem.rects
       .map((r) => ({
@@ -95,28 +138,34 @@ function composeFrame(
       });
     }
   }
-
-  for (const child of data.childIframes) {
-    const childOffset: FrameOffset = {
-      x: offset.x + child.contentOffsets.x,
-      y: offset.y + child.contentOffsets.y,
-    };
-
-    const translatedVisible: ClipRect = {
-      ...child.visibleViewport,
-      x: child.visibleViewport.x + offset.x,
-      y: child.visibleViewport.y + offset.y,
-      origin: "root-viewport",
-    };
-    const childClip: ClipRect | null =
-      clip === null
-        ? translatedVisible
-        : Rect.intersection(translatedVisible.type, translatedVisible, clip);
-
-    result.push(
-      ...composeFrame(child.childFrameId, childOffset, childClip, frameData),
-    );
-  }
-
   return result;
+}
+
+// Compose a child frame's placement from its parent's placement and the child
+// geometry the parent reported.
+function childPlacement(
+  parent: FramePlacement,
+  child: ChildIframe,
+): FramePlacement {
+  const offset: FrameOffset = {
+    x: parent.offset.x + child.contentOffsets.x,
+    y: parent.offset.y + child.contentOffsets.y,
+  };
+
+  const translatedVisible: ClipRect = {
+    ...child.visibleViewport,
+    x: child.visibleViewport.x + parent.offset.x,
+    y: child.visibleViewport.y + parent.offset.y,
+    origin: "root-viewport",
+  };
+  const clip: ClipRect | null =
+    parent.clip === null
+      ? translatedVisible
+      : Rect.intersection(
+          translatedVisible.type,
+          translatedVisible,
+          parent.clip,
+        );
+
+  return { offset, clip };
 }


### PR DESCRIPTION
## Summary

The `chrome.runtime` migration (#92) centralised rect composition in the background but, as a side effect, collapsed aggregation into a single `ResponseRectsFragment` sent only after **every** frame responded — the original incremental/streaming rendering was effectively dead.

This PR restores genuine incremental rendering **without** touching the protocol, the root-frame client, or the hinter. The streaming machinery on the root side (`RectAggregatorClient.aggregate()` generator + `for await` in `HinterContentRoot.attachHints`) already accepts multiple fragments; only the background needed to emit them incrementally.

## How it works

A frame's local rects can only be placed in root-viewport coordinates once the cumulative offset/clip of its **whole ancestor chain** is known (that geometry is reported by each parent in its `childIframes`). So the background:

1. Fans out `FetchFrameRects` to all known frames in parallel (unchanged).
2. As each response arrives, runs `emitFrame`: if the frame's placement (ancestor chain) **and** its own data are both available, it emits a `ResponseRectsFragment` for just that frame, then derives its children's placements and tries to emit any already-received children.

Root emits immediately; each descendant streams as soon as it and its ancestors are in. Coordinate math (`composeElements` / `childPlacement`) is the exact logic extracted from the previous recursive `composeFrame`, so output is identical — only the timing/granularity of delivery changes.

The empty-fragment hang guard and the root-missing warning are preserved.

## Scope

- Single file: `src/background/rect-aggregator.ts`.
- No changes to `chrome-messages.ts`, `rect-aggregator-client.ts`, `hinter.ts`, or `content-all/rect-aggregator.ts`.

## Testing

- `npm run lint && npm run test` green.
- Full Playwright E2E suite green (incl. child/grandchild iframe hint placement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)