### PR TITLE
Drop streaming aggregation: collapse to a single request/response

### DIFF
--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -4,18 +4,15 @@ import { getAllFrameIds } from "./frame-registry";
 import { Rect } from "../lib/rects";
 
 export const router = Router.newInstance()
-  .add("InitAllRects", async ({ requestId }, sender) => {
+  .add("InitAllRects", async (_payload, sender) => {
     const tabId = requireTabId(sender);
     const frameIds = getAllFrameIds(tabId);
 
     const responses = await Promise.allSettled(
       frameIds.map(async (frameId) => {
-        const response = await sendToTab(
-          tabId,
-          "FetchFrameRects",
-          { requestId },
-          { frameId },
-        );
+        const response = await sendToTab(tabId, "FetchFrameRects", undefined, {
+          frameId,
+        });
         return { frameId, response };
       }),
     );
@@ -29,17 +26,7 @@ export const router = Router.newInstance()
       }
     }
 
-    const composed = composeFrame(0, { x: 0, y: 0 }, null, frameData);
-
-    // Always send ResponseRectsFragment (even when empty) so that the
-    // root frame's aggregate() generator receives at least one message
-    // and does not hang indefinitely.
-    await sendToTab(
-      tabId,
-      "ResponseRectsFragment",
-      { requestId, rects: composed },
-      { frameId: 0 },
-    );
+    return composeFrame(0, { x: 0, y: 0 }, null, frameData);
   })
 
   .add("ExecuteAction", async (message, sender) => {

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -83,9 +83,7 @@ const router = ChromeMessageRouter.newInstance()
   .add("ExecuteAction", ({ id, options }) =>
     rectAggregator.handleExecuteAction(id.index, options),
   )
-  .add("FetchFrameRects", ({ requestId }) =>
-    rectAggregator.handleFetchFrameRects(requestId),
-  );
+  .add("FetchFrameRects", () => rectAggregator.handleFetchFrameRects());
 if (parent !== window) {
   router.add("BlurRelay", ({ childFrameId, rect }) =>
     blurer.handleBlurRelay(childFrameId, rect),

--- a/src/content-all/rect-aggregator.ts
+++ b/src/content-all/rect-aggregator.ts
@@ -21,13 +21,8 @@ export class RectAggregatorContentAll {
 
   constructor(private iframeMap: Map<number, HTMLIFrameElement>) {}
 
-  async handleFetchFrameRects(requestId: number) {
-    console.debug(
-      "FetchFrameRects requestId=",
-      requestId,
-      "location=",
-      location.href,
-    );
+  async handleFetchFrameRects() {
+    console.debug("FetchFrameRects location=", location.href);
 
     const clientRectsFetcher = new CachedFetcher((e: Element) =>
       getClientRects(e),

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -39,9 +39,6 @@ chrome.storage.onChanged.addListener((changes) => {
 
 chrome.runtime.onMessage.addListener(
   ChromeMessageRouter.newInstance()
-    .add("ResponseRectsFragment", (m) =>
-      rectAggregator.handleRects(m.requestId, m.rects),
-    )
     .add("AttachHints", () => hinter.attachHints())
     .add("HitHint", ({ key }) => hinter.hitHint(key))
     .add("RemoveHints", ({ options, execute }) =>

--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -42,10 +42,6 @@ export class HintView {
     this.style.textContent = css;
   }
 
-  isStarted(): boolean {
-    return Boolean(this.hints);
-  }
-
   start() {
     if (this.hints) throw Error("Illegal state");
     const body = document.body;

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -36,21 +36,20 @@ export class HinterContentRoot {
 
     await waitUntil(() => Boolean(document.body));
 
-    const hintTextGenerator = this.generateHintTexts();
-    for await (const elementRects of this.rectAggregator.aggregate()) {
-      if (!this.view.isStarted()) this.view.start();
-      if (elementRects.length === 0) continue;
-      const hintTexts = take(hintTextGenerator, elementRects.length);
-      hintTexts.sort(this.compareByHintLettersOrder());
-      const targets: HintedElement[] = [
-        ...map(
-          zip(elementRects, hintTexts),
-          ([er, hint]): HintedElement => ({ state: "init", hint, ...er }),
-        ),
-      ];
-      this.context.targets.push(...targets);
-      this.view.render(targets);
-    }
+    const elementRects = await this.rectAggregator.aggregate();
+    this.view.start();
+    if (elementRects.length === 0) return;
+
+    const hintTexts = take(this.generateHintTexts(), elementRects.length);
+    hintTexts.sort(this.compareByHintLettersOrder());
+    const targets: HintedElement[] = [
+      ...map(
+        zip(elementRects, hintTexts),
+        ([er, hint]): HintedElement => ({ state: "init", hint, ...er }),
+      ),
+    ];
+    this.context.targets.push(...targets);
+    this.view.render(targets);
   }
 
   // TODO We can meke this function better for keyboard typing.

--- a/src/content-root/rect-aggregator-client.ts
+++ b/src/content-root/rect-aggregator-client.ts
@@ -1,60 +1,19 @@
 import { sendToRuntime } from "../lib/chrome-messages";
-import { createQueue } from "../lib/generators";
 
 export class RectAggregatorClient {
-  private requestIndex = 0;
-  private callback:
-    | ((elementRects: ElementRects[] | "Complete") => void)
-    | null = null;
-
   constructor() {
     if (window !== window.parent) {
       throw Error("RectAggregatorClient should be created in top frame");
     }
   }
 
-  async *aggregate(): AsyncGenerator<ElementRects[]> {
-    if (this.callback) throw Error("Illegal state: already fetching");
-
-    const requestId = ++this.requestIndex;
-    const { enqueue, dequeue } = createQueue<ElementRects[] | "Complete">();
-
-    // Set callback before sending InitAllRects: background sends ResponseRectsFragment
-    // before returning, so the callback must be ready when it arrives.
-    this.callback = (rects) => enqueue.next(rects);
-    sendToRuntime("InitAllRects", { requestId }).catch((e) => {
-      console.warn(e);
-      // Unblock the generator if the background handler fails before
-      // sending ResponseRectsFragment so that aggregate() does not hang.
-      enqueue.next("Complete");
-    });
-
-    for await (const rects of dequeue) {
-      if (rects === "Complete") {
-        return;
-      } else if (rects) {
-        yield rects;
-      }
-    }
-  }
-
-  handleRects(requestId: number, rects: ElementRects[]) {
-    if (requestId !== this.requestIndex) {
-      console.warn("Unexpected requestId: ", requestId);
-      return;
-    }
-    if (!this.callback) {
-      console.warn("Not aggregating phase: ", rects);
-      return;
-    }
-    this.callback(rects);
+  // Ask the background to fan out to every frame and return the composed,
+  // root-viewport rects in a single response.
+  aggregate(): Promise<ElementRects[]> {
+    return sendToRuntime("InitAllRects");
   }
 
   action(elementId: ElementId | undefined, options: ActionOptions) {
-    if (!this.callback) throw Error("Illegal state: not aggregating");
-    const callback = this.callback;
-    this.callback = null;
-    callback("Complete");
     if (elementId)
       return sendToRuntime("ExecuteAction", { id: elementId, options });
   }

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -58,14 +58,15 @@ export interface Messages {
     };
     response: void;
   };
-  // Root frame → background: start fan-out to collect rects from all frames.
+  // Root frame → background: fan out to all frames and return the composed,
+  // root-viewport rects in a single response.
   InitAllRects: {
-    payload: { requestId: number };
-    response: void;
+    payload: void;
+    response: ElementRects[];
   };
   // Background → each frame: request local rects + child iframe geometry.
   FetchFrameRects: {
-    payload: { requestId: number };
+    payload: void;
     response: {
       elements: {
         index: number;
@@ -81,13 +82,6 @@ export interface Messages {
   };
   ExecuteAction: {
     payload: { id: ElementId; options: ActionOptions };
-    response: void;
-  };
-  ResponseRectsFragment: {
-    payload: {
-      requestId: number;
-      rects: ElementRects[];
-    };
     response: void;
   };
 }


### PR DESCRIPTION
## Summary

The `chrome.runtime` migration (#92) centralised rect composition in the background, which made the original per-frame **streaming** protocol degenerate: the background composes the entire frame tree and sends exactly one `ResponseRectsFragment`. The root-side generator/queue machinery now only ever yields once.

This PR removes that now-pointless indirection and models aggregation as a plain request/response.

## Changes

- **Protocol** (`chrome-messages.ts`): `InitAllRects` returns `ElementRects[]` directly. `ResponseRectsFragment` is removed, and the `requestId` correlation is dropped from `InitAllRects` / `FetchFrameRects`.
- **Background** (`rect-aggregator.ts`): `InitAllRects` returns the composed rects instead of pushing a fragment back to frame 0.
- **Root client** (`rect-aggregator-client.ts`): `aggregate()` is a single `await sendToRuntime("InitAllRects")`. The `createQueue` callback/generator plumbing, `handleRects`, and `requestIndex` are gone. `action()` keeps only the `ExecuteAction` call.
- **Hinter** (`hinter.ts`): `attachHints` renders once instead of looping an async generator.
- **Cleanup**: removed the now-unused `HintView.isStarted()` and the `ResponseRectsFragment` handler in `content-root.ts`.

## Trade-off vs. #96

This is the opposite direction to #96 (which *restores* genuine incremental rendering). Pick one:

- **This PR**: simplest possible model. No incremental hint rendering — hints appear once all frames have responded. Best when frame counts are small and latency is dominated by the slowest frame anyway.
- **#96**: keeps the streaming machinery and makes the background actually stream per-frame fragments as ancestors resolve.

## Testing

- `npm run lint && npm run test` green.
- Full Playwright E2E suite green (incl. child/grandchild iframe hint placement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)