### PR TITLE
Fix isEditable: check disabled/readOnly/aria on custom elements

### DIFF
--- a/src/dom/elements.ts
+++ b/src/dom/elements.ts
@@ -43,8 +43,21 @@ export function isEditable(element: EventTarget) {
     );
   if (element instanceof HTMLTextAreaElement)
     return !element.disabled && !element.readOnly;
-  if ("selectionStart" in element && element.selectionStart != null)
-    return true; // custom elements exposing the selection API
+  if ("selectionStart" in element && element.selectionStart != null) {
+    // custom elements exposing the selection API
+    const el = element as unknown as {
+      disabled?: boolean;
+      readOnly?: boolean;
+      getAttribute?: (name: string) => string | null;
+    };
+    if (el.disabled || el.readOnly) return false;
+    if (
+      el.getAttribute?.("aria-disabled") === "true" ||
+      el.getAttribute?.("aria-readonly") === "true"
+    )
+      return false;
+    return true;
+  }
   return "isContentEditable" in element && Boolean(element.isContentEditable);
 }
 

--- a/test/dom/elements.test.ts
+++ b/test/dom/elements.test.ts
@@ -95,6 +95,53 @@ void describe("isEditable", () => {
       assert.equal(isEditable(textarea({ readOnly: true })), false));
   });
 
+  void describe("custom element with selectionStart", () => {
+    function customEl(
+      overrides: {
+        disabled?: boolean;
+        readOnly?: boolean;
+        "aria-disabled"?: string;
+        "aria-readonly"?: string;
+      } = {},
+    ): EventTarget {
+      const attrs = new Map<string, string>();
+      if (overrides["aria-disabled"])
+        attrs.set("aria-disabled", overrides["aria-disabled"]);
+      if (overrides["aria-readonly"])
+        attrs.set("aria-readonly", overrides["aria-readonly"]);
+      return {
+        selectionStart: 0,
+        disabled: overrides.disabled,
+        readOnly: overrides.readOnly,
+        getAttribute(name: string) {
+          return attrs.get(name) ?? null;
+        },
+        /* eslint-disable @typescript-eslint/no-empty-function */
+        addEventListener() {},
+        dispatchEvent() {
+          return true;
+        },
+        removeEventListener() {},
+        /* eslint-enable @typescript-eslint/no-empty-function */
+      } as unknown as EventTarget;
+    }
+
+    void test("custom element with selectionStart is editable", () =>
+      assert.equal(isEditable(customEl()), true));
+
+    void test("custom element with disabled=true is not editable", () =>
+      assert.equal(isEditable(customEl({ disabled: true })), false));
+
+    void test("custom element with readOnly=true is not editable", () =>
+      assert.equal(isEditable(customEl({ readOnly: true })), false));
+
+    void test('custom element with aria-disabled="true" is not editable', () =>
+      assert.equal(isEditable(customEl({ "aria-disabled": "true" })), false));
+
+    void test('custom element with aria-readonly="true" is not editable', () =>
+      assert.equal(isEditable(customEl({ "aria-readonly": "true" })), false));
+  });
+
   void describe("contenteditable", () => {
     void test("contenteditable element is editable", () =>
       assert.equal(


### PR DESCRIPTION
## Summary

- The `selectionStart` branch in `isEditable` (`src/dom/elements.ts`) previously returned `true` unconditionally for any custom element exposing the Selection API.
- Now it checks the optional `disabled` and `readOnly` properties (falsy if absent), and also checks `aria-disabled="true"` / `aria-readonly="true"` attributes via optional chaining on `getAttribute`.
- Five new unit tests cover: editable, disabled, readOnly, aria-disabled, and aria-readonly cases.

Closes #84