### PR TITLE
Fix blur: proceed even when active element has no visible rect

### DIFF
--- a/docs/tests/hidden-iframe-child.html
+++ b/docs/tests/hidden-iframe-child.html
@@ -1,0 +1,2 @@
+<p>Child frame (inside a hidden iframe)</p>
+<input id="hidden-input" type="text" placeholder="hidden input" autofocus />

--- a/docs/tests/hidden-iframe.html
+++ b/docs/tests/hidden-iframe.html
@@ -1,19 +1,28 @@
 <style>
   iframe {
+    position: absolute;
+    top: 30px;
+    left: 30px;
+    width: 400px;
+    height: 200px;
+    border: none;
+  }
+  iframe.hidden {
     display: none;
+  }
+  #root-section {
+    margin-top: 260px;
+  }
+  #status {
+    font-family: monospace;
   }
 </style>
 
-<p>Root frame — the child iframe is hidden (display:none).</p>
-<p id="status">not blurred</p>
+<!-- The iframe starts visible so the child element can receive focus,
+     then the test hides it to simulate a zero-rect scenario. -->
+<iframe id="child-iframe" src="hidden-iframe-child.html"></iframe>
 
-<iframe id="hidden-iframe" src="hidden-iframe-child.html"></iframe>
-
-<script>
-  document.addEventListener("focusin", () => {
-    document.getElementById("status").textContent = "focused";
-  });
-  document.addEventListener("focusout", () => {
-    document.getElementById("status").textContent = "blurred";
-  });
-</script>
+<div id="root-section">
+  <p>Root frame</p>
+  <p id="status">idle</p>
+</div>

--- a/docs/tests/hidden-iframe.html
+++ b/docs/tests/hidden-iframe.html
@@ -1,0 +1,19 @@
+<style>
+  iframe {
+    display: none;
+  }
+</style>
+
+<p>Root frame — the child iframe is hidden (display:none).</p>
+<p id="status">not blurred</p>
+
+<iframe id="hidden-iframe" src="hidden-iframe-child.html"></iframe>
+
+<script>
+  document.addEventListener("focusin", () => {
+    document.getElementById("status").textContent = "focused";
+  });
+  document.addEventListener("focusout", () => {
+    document.getElementById("status").textContent = "blurred";
+  });
+</script>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint --flag unstable_native_nodejs_ts_config --cache --cache-strategy content --fix .",
     "fix:prettier": "prettier --write --log-level error --cache --cache-strategy content .",
-    "test": "tsx --test test/lib/*.test.ts test/background/*.test.ts test/dom/*.test.ts test/content-all/*.test.ts",
+    "test": "tsx --test test/lib/*.test.ts test/background/*.test.ts test/dom/*.test.ts test/content-all/*.test.ts test/content-root/*.test.ts",
     "test:e2e": "playwright test",
     "check": "run-s lint test",
     "watch": "run-p watch:build watch:serve",

--- a/src/content-all/blurer.ts
+++ b/src/content-all/blurer.ts
@@ -35,16 +35,10 @@ function buildBlurRect(
   sourceIframe: HTMLIFrameElement,
   originRectJson: RectJSON<"element-border", "layout-viewport"> | null,
 ): Rect<"element-border", "layout-viewport"> | null {
-  if (!originRectJson) {
-    console.warn("Unexpected origin rect:", originRectJson);
-    return null;
-  }
+  if (!originRectJson) return null;
 
   const sourceViewport = getContentRects(sourceIframe)[0];
-  if (!sourceViewport) {
-    console.warn("No viewport:", sourceIframe);
-    return null;
-  }
+  if (!sourceViewport) return null;
 
   const originRect = new Rect({ ...originRectJson, origin: "element-content" });
   return originRect.offsets(sourceViewport.reverse());

--- a/src/content-root/blurer.ts
+++ b/src/content-root/blurer.ts
@@ -8,15 +8,11 @@ export class BlurerContentRoot {
   constructor(private view: BlurView) {}
 
   handleBlurRoot(rect: RectJSON<"element-border", "layout-viewport"> | null) {
-    if (!rect) {
-      console.warn("Unexpected rect:", rect);
-      return;
-    }
-
     const activeElement = document.activeElement;
     if (!activeElement || !("blur" in activeElement)) return;
     (activeElement.blur as () => void)();
 
+    if (!rect) return;
     // In the root frame, layout-viewport coordinates equal root-viewport coordinates.
     this.view.blur(new Rect({ ...rect, origin: "root-viewport" }));
   }

--- a/test/content-all/blurer.test.ts
+++ b/test/content-all/blurer.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const sentToRuntime: { type: string; payload: unknown }[] = [];
+
+(globalThis as Record<string, unknown>).chrome = {
+  runtime: {
+    sendMessage: (msg: { "@type": string }) => {
+      sentToRuntime.push({ type: msg["@type"], payload: msg });
+      if (msg["@type"] === "GetFrameId")
+        return Promise.resolve({ response: 10 });
+      return Promise.resolve({ response: undefined });
+    },
+  },
+};
+
+const fakeWindow = {};
+(globalThis as Record<string, unknown>).window = fakeWindow;
+(globalThis as Record<string, unknown>).parent = fakeWindow;
+
+const { BlurerContentAll } = await import("../../src/content-all/blurer.js");
+const { FrameRegistry } =
+  await import("../../src/content-all/frame-registration.js");
+
+function makeRegistry(): InstanceType<typeof FrameRegistry> {
+  return new FrameRegistry();
+}
+
+function makeRectJson(
+  overrides: Partial<RectJSON<"element-border", "layout-viewport">> = {},
+): RectJSON<"element-border", "layout-viewport"> {
+  return {
+    type: "element-border",
+    origin: "layout-viewport",
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 50,
+    ...overrides,
+  };
+}
+
+void describe("BlurerContentAll.handleBlurRelay", () => {
+  beforeEach(() => {
+    sentToRuntime.length = 0;
+  });
+
+  void test("propagates null rect as-is when input rect is null", async () => {
+    const registry = makeRegistry();
+
+    const fakeSource = { window: {} } as unknown as Window;
+    const fakeIframe = {
+      contentWindow: fakeSource,
+      isConnected: true,
+    } as unknown as HTMLIFrameElement;
+
+    (globalThis as Record<string, unknown>).document = {
+      getElementsByTagName: () => [fakeIframe],
+    };
+
+    registry.handleMessage({
+      data: {
+        "@type": "com.github.kui.knavi.FrameIdAnnouncement",
+        frameId: 5,
+      },
+      source: fakeSource,
+    } as MessageEvent);
+
+    // Clear GetFrameId messages recorded during registry setup.
+    sentToRuntime.length = 0;
+
+    const blurer = new BlurerContentAll(registry);
+    blurer.handleBlurRelay(5, null);
+
+    // Wait for the async sendToRuntime call.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(sentToRuntime.length, 1);
+    const sent = sentToRuntime[0];
+    assert.equal(sent.type, "BlurUp");
+    // null rect must be forwarded, not swallowed
+    assert.equal((sent.payload as Record<string, unknown>).rect, null);
+  });
+
+  void test("propagates null rect when iframe has no renderable content rect", async () => {
+    const registry = makeRegistry();
+
+    const fakeSource = { window: {} } as unknown as Window;
+    // getClientRects returns an empty iterable (zero-size / display:none iframe).
+    const fakeIframe = {
+      contentWindow: fakeSource,
+      isConnected: true,
+      getClientRects: () => [] as DOMRect[],
+      computedStyleMap: () => ({ get: () => undefined }),
+    } as unknown as HTMLIFrameElement;
+
+    (globalThis as Record<string, unknown>).document = {
+      getElementsByTagName: () => [fakeIframe],
+    };
+
+    registry.handleMessage({
+      data: {
+        "@type": "com.github.kui.knavi.FrameIdAnnouncement",
+        frameId: 6,
+      },
+      source: fakeSource,
+    } as MessageEvent);
+
+    sentToRuntime.length = 0;
+
+    const blurer = new BlurerContentAll(registry);
+    blurer.handleBlurRelay(6, makeRectJson());
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(sentToRuntime.length, 1);
+    assert.equal(sentToRuntime[0].type, "BlurUp");
+    assert.equal(
+      (sentToRuntime[0].payload as Record<string, unknown>).rect,
+      null,
+    );
+  });
+});

--- a/test/content-root/blurer.test.ts
+++ b/test/content-root/blurer.test.ts
@@ -1,0 +1,90 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+// BlurerContentRoot is loaded in the root frame only.
+(globalThis as Record<string, unknown>).parent = globalThis;
+(globalThis as Record<string, unknown>).window = globalThis;
+
+const { BlurerContentRoot } = await import("../../src/content-root/blurer.js");
+
+interface BlurViewLike {
+  blur: (rect: unknown) => void;
+}
+
+function makeView(): BlurViewLike & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    blur(rect: unknown) {
+      calls.push(rect);
+    },
+  };
+}
+
+function makeActiveElement(blurred: { count: number }) {
+  return {
+    blur() {
+      blurred.count++;
+    },
+  };
+}
+
+void describe("BlurerContentRoot.handleBlurRoot", () => {
+  void test("calls activeElement.blur() and runs animation when rect is provided", () => {
+    const view = makeView();
+    const blurred = { count: 0 };
+
+    (globalThis as Record<string, unknown>).document = {
+      activeElement: makeActiveElement(blurred),
+    };
+
+    const blurer = new BlurerContentRoot(view as never);
+    blurer.handleBlurRoot({
+      type: "element-border",
+      origin: "layout-viewport",
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+    });
+
+    assert.equal(blurred.count, 1, "blur() should be called");
+    assert.equal(
+      view.calls.length,
+      1,
+      "view.blur() should be called with rect",
+    );
+  });
+
+  void test("calls activeElement.blur() but skips animation when rect is null", () => {
+    const view = makeView();
+    const blurred = { count: 0 };
+
+    (globalThis as Record<string, unknown>).document = {
+      activeElement: makeActiveElement(blurred),
+    };
+
+    const blurer = new BlurerContentRoot(view as never);
+    blurer.handleBlurRoot(null);
+
+    assert.equal(blurred.count, 1, "blur() must be called even with null rect");
+    assert.equal(
+      view.calls.length,
+      0,
+      "view.blur() must NOT be called when rect is null",
+    );
+  });
+
+  void test("no-ops when document.activeElement is null", () => {
+    const view = makeView();
+
+    (globalThis as Record<string, unknown>).document = {
+      activeElement: null,
+    };
+
+    const blurer = new BlurerContentRoot(view as never);
+    blurer.handleBlurRoot(null);
+
+    assert.equal(view.calls.length, 0);
+  });
+});

--- a/test/content-root/tsconfig.json
+++ b/test/content-root/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["node", "chrome"]
+  },
+  "include": ["./*.ts", "../../src/types", "../../types"],
+  "references": [{ "path": "../../src/tsconfig.content-root.json" }]
+}

--- a/test/e2e/blur.spec.ts
+++ b/test/e2e/blur.spec.ts
@@ -66,4 +66,44 @@ test.describe("blur", () => {
     await grandchildFrame.locator("body").press("Escape");
     await expect(input).not.toBeFocused({ timeout: 3_000 });
   });
+
+  test("hidden iframe: blur key blurs the focused input even when iframe is display:none", async ({
+    page,
+  }) => {
+    await gotoTest(page, "hidden-iframe.html");
+
+    // Programmatically focus the input inside the hidden (display:none) iframe.
+    // Playwright cannot click into a hidden iframe, so we use JS.
+    const childFrame = page
+      .frames()
+      .find((f) => f.url().includes("hidden-iframe-child"));
+    if (!childFrame) throw new Error("hidden-iframe-child frame not found");
+
+    await childFrame.evaluate(() => {
+      const el = document.querySelector<HTMLInputElement>("#hidden-input");
+      el?.focus();
+    });
+
+    // Confirm focus reached the child frame's document.
+    const isFocused = await childFrame.evaluate(
+      () => document.activeElement?.id === "hidden-input",
+    );
+    if (!isFocused) throw new Error("focus did not land on #hidden-input");
+
+    // Press blur key from the root frame.
+    await page.keyboard.press("Escape");
+
+    // The input must lose focus.
+    await expect
+      .poll(
+        () =>
+          childFrame.evaluate(
+            () =>
+              document.activeElement === document.body ||
+              document.activeElement == null,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(true);
+  });
 });

--- a/test/e2e/blur.spec.ts
+++ b/test/e2e/blur.spec.ts
@@ -72,32 +72,31 @@ test.describe("blur", () => {
   }) => {
     await gotoTest(page, "hidden-iframe.html");
 
-    // Programmatically focus the input inside the hidden (display:none) iframe.
-    // Playwright cannot click into a hidden iframe, so we use JS.
-    const childFrame = page
-      .frames()
-      .find((f) => f.url().includes("hidden-iframe-child"));
-    if (!childFrame) throw new Error("hidden-iframe-child frame not found");
+    // The iframe starts visible. Click the input to focus it.
+    const childFrame = page.frameLocator("#child-iframe");
+    const input = childFrame.locator("#hidden-input");
+    await input.click();
+    await expect(input).toBeFocused();
 
-    await childFrame.evaluate(() => {
-      const el = document.querySelector<HTMLInputElement>("#hidden-input");
-      el?.focus();
+    // Now hide the iframe so its content rect disappears (simulates an
+    // invisible iframe whose focused element can still intercept keys).
+    await page.evaluate(() => {
+      document.getElementById("child-iframe")?.classList.add("hidden");
     });
-
-    // Confirm focus reached the child frame's document.
-    const isFocused = await childFrame.evaluate(
-      () => document.activeElement?.id === "hidden-input",
-    );
-    if (!isFocused) throw new Error("focus did not land on #hidden-input");
 
     // Press blur key from the root frame.
     await page.keyboard.press("Escape");
 
-    // The input must lose focus.
+    // The input must lose focus even though the iframe has no visible rect.
+    const rawFrame = page
+      .frames()
+      .find((f) => f.url().includes("hidden-iframe-child"));
+    if (!rawFrame) throw new Error("hidden-iframe-child frame not found");
+
     await expect
       .poll(
         () =>
-          childFrame.evaluate(
+          rawFrame.evaluate(
             () =>
               document.activeElement === document.body ||
               document.activeElement == null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "test/dom/tsconfig.json" },
     { "path": "test/background/tsconfig.json" },
     { "path": "test/content-all/tsconfig.json" },
+    { "path": "test/content-root/tsconfig.json" },
     { "path": "test/e2e/tsconfig.json" },
     { "path": "scripts/tsconfig.json" }
   ]


### PR DESCRIPTION
## Summary

- `handleBlurRoot` (`src/content-root/blurer.ts`) now calls `activeElement.blur()` unconditionally; the `view.blur()` animation is only run when `rect` is non-null.
- `buildBlurRect` / `handleBlurRelay` (`src/content-all/blurer.ts`) propagate `null` rect as-is rather than treating it as an error — the root frame decides what to do.
- Unit tests added for `BlurerContentAll` (null-rect relay path) and `BlurerContentRoot` (blur-without-animation path).
- E2E test added: blur key dismisses focus on an element inside a `display:none` iframe.

Fixes #104

## Test plan

- [x] `npm run lint && npm run test` passes (93/93 unit tests)
- [x] New unit tests cover: null rect forwarded by relay frames; `activeElement.blur()` called even when rect is null; animation skipped when rect is null
- [x] New E2E test (`hidden-iframe.html`): blur key removes focus from input inside a hidden iframe
- [x] Existing blur E2E tests unchanged (normal visible-iframe path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)