### PR TITLE
Split Messages into RuntimeMessages / TabMessages by channel

### DIFF
--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,9 +1,19 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
 import { requireTabId } from "./sender-guards";
 
-export const router = Router.newInstance().addAll(
-  ["AttachHints", "RemoveHints", "HitHint"],
-  (type) => async (msg, sender) => {
-    return await sendToTab(requireTabId(sender), type, msg, { frameId: 0 });
-  },
-);
+export const router = Router.newInstance()
+  .add("AttachHints", async (msg, sender) => {
+    return await sendToTab(requireTabId(sender), "AttachHintsInTab", msg, {
+      frameId: 0,
+    });
+  })
+  .add("HitHint", async (msg, sender) => {
+    return await sendToTab(requireTabId(sender), "HitHintInTab", msg, {
+      frameId: 0,
+    });
+  })
+  .add("RemoveHints", async (msg, sender) => {
+    return await sendToTab(requireTabId(sender), "RemoveHintsInTab", msg, {
+      frameId: 0,
+    });
+  });

--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -2,18 +2,31 @@ import { Router, sendToTab } from "../lib/chrome-messages";
 import { requireTabId } from "./sender-guards";
 
 export const router = Router.newInstance()
-  .add("AttachHints", async (msg, sender) => {
-    return await sendToTab(requireTabId(sender), "AttachHintsInTab", msg, {
-      frameId: 0,
-    });
+  .add("AttachHints", async (_msg, sender) => {
+    return await sendToTab(
+      requireTabId(sender),
+      "AttachHintsInTab",
+      undefined,
+      {
+        frameId: 0,
+      },
+    );
   })
-  .add("HitHint", async (msg, sender) => {
-    return await sendToTab(requireTabId(sender), "HitHintInTab", msg, {
-      frameId: 0,
-    });
+  .add("HitHint", async ({ key }, sender) => {
+    return await sendToTab(
+      requireTabId(sender),
+      "HitHintInTab",
+      { key },
+      {
+        frameId: 0,
+      },
+    );
   })
-  .add("RemoveHints", async (msg, sender) => {
-    return await sendToTab(requireTabId(sender), "RemoveHintsInTab", msg, {
-      frameId: 0,
-    });
+  .add("RemoveHints", async ({ options, execute }, sender) => {
+    return await sendToTab(
+      requireTabId(sender),
+      "RemoveHintsInTab",
+      { options, execute },
+      { frameId: 0 },
+    );
   });

--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,7 +1,7 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
 import { requireTabId } from "./sender-guards";
 
-export const router = Router.newInstance()
+export const router = Router.newRuntimeInstance()
   .add("AttachHints", async (_msg, sender) => {
     return await sendToTab(
       requireTabId(sender),

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -1,7 +1,7 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
 import { requireFrameId, requireTabId } from "./sender-guards";
 
-export const router = Router.newInstance()
+export const router = Router.newRuntimeInstance()
   .add("GetFrameId", (_, sender) => requireFrameId(sender))
 
   .add("ResponseRectsFragment", async (message, sender) => {

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -11,7 +11,7 @@ export const router = Router.newInstance()
   })
 
   .add("ExecuteAction", async (message, sender) => {
-    await sendToTab(requireTabId(sender), "ExecuteAction", message, {
+    await sendToTab(requireTabId(sender), "ExecuteActionInFrame", message, {
       frameId: message.id.frameId,
     });
   })

--- a/src/background/rect-aggregator.ts
+++ b/src/background/rect-aggregator.ts
@@ -10,10 +10,13 @@ export const router = Router.newInstance()
     });
   })
 
-  .add("ExecuteAction", async (message, sender) => {
-    await sendToTab(requireTabId(sender), "ExecuteActionInFrame", message, {
-      frameId: message.id.frameId,
-    });
+  .add("ExecuteAction", async ({ id, options }, sender) => {
+    await sendToTab(
+      requireTabId(sender),
+      "ExecuteActionInFrame",
+      { id, options },
+      { frameId: id.frameId },
+    );
   })
 
   .add(

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -22,7 +22,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     .catch(printError);
 });
 
-export const router = Router.newInstance()
+export const router = Router.newRuntimeInstance()
   .add("GetSettings", async (message) => {
     const storage = await settings.getStorage();
     return storage.get(message.names);

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -74,7 +74,7 @@ window.navigation?.addEventListener("navigatesuccess", () => {
 });
 
 chrome.runtime.onMessage.addListener(
-  ChromeMessageRouter.newInstance()
+  ChromeMessageRouter.newTabInstance()
     .add("ExecuteActionInFrame", ({ id, options }) =>
       rectAggregator.handleExecuteAction(id.index, options),
     )

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -75,7 +75,7 @@ window.navigation?.addEventListener("navigatesuccess", () => {
 
 chrome.runtime.onMessage.addListener(
   ChromeMessageRouter.newInstance()
-    .add("ExecuteAction", ({ id, options }) =>
+    .add("ExecuteActionInFrame", ({ id, options }) =>
       rectAggregator.handleExecuteAction(id.index, options),
     )
     .add("AllRectsRequest", async ({ id, viewport, offsets }) => {
@@ -88,11 +88,11 @@ chrome.runtime.onMessage.addListener(
     .add("BlurRelay", ({ childFrameId, rect }) => {
       blurer.handleBlurRelay(childFrameId, rect);
     })
-    // Passively observe AttachHints/RemoveHints forwarded to the root frame
+    // Passively observe AttachHintsInTab/RemoveHintsInTab forwarded to the root frame
     // (frameId:0). Keeps the root frame's keyboard handler in sync when a
     // child frame initiated the hint session. content-root.ts owns sendResponse.
-    .addPassive("AttachHints", () => hinterClient.syncHinting(true))
-    .addPassive("RemoveHints", () => hinterClient.syncHinting(false))
+    .addPassive("AttachHintsInTab", () => hinterClient.syncHinting(true))
+    .addPassive("RemoveHintsInTab", () => hinterClient.syncHinting(false))
     .buildListener(),
 );
 

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -36,9 +36,9 @@ chrome.runtime.onMessage.addListener(
     .add("ResponseRectsFragment", (m) =>
       rectAggregator.handleRects(m.requestId, m.rects),
     )
-    .add("AttachHints", () => hinter.attachHints())
-    .add("HitHint", ({ key }) => hinter.hitHint(key))
-    .add("RemoveHints", ({ options, execute }) =>
+    .add("AttachHintsInTab", () => hinter.attachHints())
+    .add("HitHintInTab", ({ key }) => hinter.hitHint(key))
+    .add("RemoveHintsInTab", ({ options, execute }) =>
       hinter.removeHints(options, execute),
     )
     .add("BlurRoot", ({ rect }) => blurer.handleBlurRoot(rect))

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -32,7 +32,7 @@ chrome.storage.onChanged.addListener((changes) => {
 });
 
 chrome.runtime.onMessage.addListener(
-  ChromeMessageRouter.newInstance()
+  ChromeMessageRouter.newTabInstance()
     .add("ResponseRectsFragment", (m) =>
       rectAggregator.handleRects(m.requestId, m.rects),
     )

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -1,8 +1,7 @@
 import type { SingleLetter } from "./strings";
 
-// TODO separate by the handler (background, content, popup, etc)
-interface Messages {
-  // Settings
+interface RuntimeMessages {
+  // Settings — received by background
   GetSettings: {
     payload: { names: (keyof Settings)[] };
     response: Pick<Settings, keyof Settings>;
@@ -20,7 +19,7 @@ interface Messages {
     response: { added: boolean };
   };
 
-  // Hint
+  // Hint session — runtime hop (content → background)
   AttachHints: {
     payload: void;
     response: void;
@@ -33,6 +32,8 @@ interface Messages {
     payload: { options: ActionOptions; execute: boolean };
     response: void;
   };
+
+  // Rect / frame — received by background
   GetFrameId: {
     payload: void;
     response: number;
@@ -64,6 +65,44 @@ interface Messages {
     };
     response: void;
   };
+}
+
+interface TabMessages {
+  // Hint session — tab hop (background → content-root)
+  AttachHintsInTab: {
+    payload: void;
+    response: void;
+  };
+  HitHintInTab: {
+    payload: { key: SingleLetter };
+    response: void;
+  };
+  RemoveHintsInTab: {
+    payload: { options: ActionOptions; execute: boolean };
+    response: void;
+  };
+
+  // Rect / frame — received by content
+  ExecuteActionInFrame: {
+    payload: { id: ElementId; options: ActionOptions };
+    response: void;
+  };
+  ResponseRectsFragment: {
+    payload: {
+      requestId: number;
+      rects: ElementRects[];
+    };
+    response: void;
+  };
+  AllRectsRequest: {
+    payload: {
+      id: number;
+      targetFrameId: number;
+      viewport: RectJSON<"actual-viewport", "root-viewport">;
+      offsets: CoordinatesJSON<"layout-viewport", "root-viewport">;
+    };
+    response: void;
+  };
   BlurRelay: {
     payload: {
       childFrameId: number;
@@ -77,12 +116,14 @@ interface Messages {
   };
 }
 
-type Message<T extends keyof Messages> = {
+type AllMessages = RuntimeMessages & TabMessages;
+
+type Message<T extends keyof AllMessages> = {
   readonly "@type": T;
 } & MessagePayload<T>;
-type MessagePayload<T extends keyof Messages> = Messages[T]["payload"];
-type Response<T extends keyof Messages> = Messages[T]["response"];
-type Handler<T extends keyof Messages> = (
+type MessagePayload<T extends keyof AllMessages> = AllMessages[T]["payload"];
+type Response<T extends keyof AllMessages> = AllMessages[T]["response"];
+type Handler<T extends keyof AllMessages> = (
   data: MessagePayload<T>,
   sender: chrome.runtime.MessageSender,
 ) => Response<T> | Promise<Response<T>>;
@@ -90,20 +131,20 @@ type Handler<T extends keyof Messages> = (
 // A passive handler observes a message without sending a response.
 // Use addPassive() when another listener in a different script owns the
 // sendResponse for the same message type.
-type PassiveHandler<T extends keyof Messages> = (
+type PassiveHandler<T extends keyof AllMessages> = (
   data: MessagePayload<T>,
   sender: chrome.runtime.MessageSender,
 ) => void | Promise<void>;
 
-type SendResponseArg<T extends keyof Messages> =
+type SendResponseArg<T extends keyof AllMessages> =
   | { response: Response<T> }
   | { error: Error };
 
-function type<T extends keyof Messages>(m: Message<T>): T {
+function type<T extends keyof AllMessages>(m: Message<T>): T {
   return m["@type"];
 }
 
-function message<T extends keyof Messages>(
+function message<T extends keyof AllMessages>(
   type: T,
   payload: MessagePayload<T>,
 ): Message<T> {
@@ -113,15 +154,15 @@ function message<T extends keyof Messages>(
 export class Router<
   // Message types which are already registered to reject duplicate type registration.
   // If T is void, it means no message types are registered.
-  RegisteredTypes extends keyof Messages | void,
+  RegisteredTypes extends keyof AllMessages | void,
 > {
   private readonly handlers = new Map<
-    keyof Messages,
-    Handler<keyof Messages>
+    keyof AllMessages,
+    Handler<keyof AllMessages>
   >();
   private readonly passiveHandlers = new Map<
-    keyof Messages,
-    PassiveHandler<keyof Messages>
+    keyof AllMessages,
+    PassiveHandler<keyof AllMessages>
   >();
 
   // Use `newInstance` instead of `new Router`, because of managing the T.
@@ -132,24 +173,24 @@ export class Router<
     return new Router();
   }
 
-  private isRegistered(type: keyof Messages): boolean {
+  private isRegistered(type: keyof AllMessages): boolean {
     return this.handlers.has(type) || this.passiveHandlers.has(type);
   }
 
-  add<T extends Exclude<keyof Messages, RegisteredTypes>>(
+  add<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
     type: T,
     handler: Handler<T>,
   ): Router<Exclude<RegisteredTypes | T, void>> {
     if (this.isRegistered(type))
       throw Error(`Already registered: type=${type}`);
-    this.handlers.set(type, handler as unknown as Handler<keyof Messages>);
+    this.handlers.set(type, handler as unknown as Handler<keyof AllMessages>);
     return this;
   }
 
   // Register a passive handler: observes the message without sending a
   // response. Use when another listener in a different script (e.g.
   // content-root.ts) owns the sendResponse for this message type.
-  addPassive<T extends Exclude<keyof Messages, RegisteredTypes>>(
+  addPassive<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
     type: T,
     handler: PassiveHandler<T>,
   ): Router<Exclude<RegisteredTypes | T, void>> {
@@ -157,12 +198,12 @@ export class Router<
       throw Error(`Already registered: type=${type}`);
     this.passiveHandlers.set(
       type,
-      handler as unknown as PassiveHandler<keyof Messages>,
+      handler as unknown as PassiveHandler<keyof AllMessages>,
     );
     return this;
   }
 
-  addAll<T extends Exclude<keyof Messages, RegisteredTypes>>(
+  addAll<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
     types: T[],
     buildHandler: (type: T) => Handler<T>,
   ): Router<Exclude<RegisteredTypes | T, void>> {
@@ -170,7 +211,7 @@ export class Router<
     return this;
   }
 
-  merge<T extends Exclude<keyof Messages, RegisteredTypes>>(
+  merge<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
     router: Router<T>,
   ): Router<Exclude<RegisteredTypes | T, void>> {
     for (const [type, handler] of router.handlers) {
@@ -184,7 +225,7 @@ export class Router<
 
   // Returns true if the message is handled asynchronously.
   // See https://developer.chrome.com/docs/extensions/mv3/messaging/#simple.
-  private route<T extends keyof Messages>(
+  private route<T extends keyof AllMessages>(
     message: Message<T>,
     sender: chrome.runtime.MessageSender,
     sendResponse: (arg: SendResponseArg<T>) => void,
@@ -234,7 +275,7 @@ export class Router<
   }
 }
 
-function buildErrorArg<T extends keyof Messages>(
+function buildErrorArg<T extends keyof AllMessages>(
   error: unknown,
 ): SendResponseArg<T> {
   if (error instanceof Error) {
@@ -246,10 +287,10 @@ function buildErrorArg<T extends keyof Messages>(
   }
 }
 
-export async function sendToRuntime<T extends keyof Messages>(
+export async function sendToRuntime<T extends keyof RuntimeMessages>(
   type: T,
-  payload: MessagePayload<T>,
-): Promise<Response<T>> {
+  payload: RuntimeMessages[T]["payload"],
+): Promise<RuntimeMessages[T]["response"]> {
   const r = await chrome.runtime.sendMessage<Message<T>, SendResponseArg<T>>(
     message(type, payload),
   );
@@ -261,12 +302,12 @@ export async function sendToRuntime<T extends keyof Messages>(
   return r.response;
 }
 
-export async function sendToTab<T extends keyof Messages>(
+export async function sendToTab<T extends keyof TabMessages>(
   tabId: number,
   type: T,
-  payload: MessagePayload<T>,
+  payload: TabMessages[T]["payload"],
   options: chrome.tabs.MessageSendOptions = {},
-): Promise<Response<T>> {
+): Promise<TabMessages[T]["response"]> {
   const r = await chrome.tabs.sendMessage<Message<T>, SendResponseArg<T>>(
     tabId,
     message(type, payload),

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -1,6 +1,6 @@
 import type { SingleLetter } from "./strings";
 
-interface RuntimeMessages {
+export interface RuntimeMessages {
   // Settings — received by background
   GetSettings: {
     payload: { names: (keyof Settings)[] };
@@ -67,7 +67,7 @@ interface RuntimeMessages {
   };
 }
 
-interface TabMessages {
+export interface TabMessages {
   // Hint session — tab hop (background → content-root)
   AttachHintsInTab: {
     payload: void;
@@ -116,104 +116,94 @@ interface TabMessages {
   };
 }
 
-type AllMessages = RuntimeMessages & TabMessages;
+// Use conditional inference so M can be a concrete interface (no index signature needed).
+type MPayload<M, T extends keyof M> = M[T] extends { payload: infer P }
+  ? P
+  : never;
+type MResponse<M, T extends keyof M> = M[T] extends { response: infer R }
+  ? R
+  : never;
+type MMessage<M, T extends keyof M> = { readonly "@type": T } & MPayload<M, T>;
 
-type Message<T extends keyof AllMessages> = {
-  readonly "@type": T;
-} & MessagePayload<T>;
-type MessagePayload<T extends keyof AllMessages> = AllMessages[T]["payload"];
-type Response<T extends keyof AllMessages> = AllMessages[T]["response"];
-type Handler<T extends keyof AllMessages> = (
-  data: MessagePayload<T>,
+type MHandler<M, T extends keyof M> = (
+  data: MPayload<M, T>,
   sender: chrome.runtime.MessageSender,
-) => Response<T> | Promise<Response<T>>;
+) => MResponse<M, T> | Promise<MResponse<M, T>>;
 
 // A passive handler observes a message without sending a response.
 // Use addPassive() when another listener in a different script owns the
 // sendResponse for the same message type.
-type PassiveHandler<T extends keyof AllMessages> = (
-  data: MessagePayload<T>,
+type MPassiveHandler<M, T extends keyof M> = (
+  data: MPayload<M, T>,
   sender: chrome.runtime.MessageSender,
 ) => void | Promise<void>;
 
-type SendResponseArg<T extends keyof AllMessages> =
-  | { response: Response<T> }
+type MSendResponseArg<M, T extends keyof M> =
+  | { response: MResponse<M, T> }
   | { error: Error };
 
-function type<T extends keyof AllMessages>(m: Message<T>): T {
-  return m["@type"];
-}
-
-function message<T extends keyof AllMessages>(
+// Object.assign avoids TypeScript's spread-of-void complaint.
+function makeMessage<M, T extends keyof M>(
   type: T,
-  payload: MessagePayload<T>,
-): Message<T> {
-  return { "@type": type, ...payload };
+  payload: MPayload<M, T>,
+): MMessage<M, T> {
+  return Object.assign({ "@type": type }, payload);
 }
 
 export class Router<
-  // Message types which are already registered to reject duplicate type registration.
-  // If T is void, it means no message types are registered.
-  RegisteredTypes extends keyof AllMessages | void,
+  M,
+  // Message types already registered; void means none registered yet.
+  RegisteredTypes extends keyof M | void,
 > {
-  private readonly handlers = new Map<
-    keyof AllMessages,
-    Handler<keyof AllMessages>
-  >();
+  private readonly handlers = new Map<keyof M, MHandler<M, keyof M>>();
   private readonly passiveHandlers = new Map<
-    keyof AllMessages,
-    PassiveHandler<keyof AllMessages>
+    keyof M,
+    MPassiveHandler<M, keyof M>
   >();
 
-  // Use `newInstance` instead of `new Router`, because of managing the T.
+  // Use the static factories instead of `new Router`.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {}
 
-  static newInstance(): Router<void> {
+  static newRuntimeInstance(): Router<RuntimeMessages, void> {
     return new Router();
   }
 
-  private isRegistered(type: keyof AllMessages): boolean {
+  static newTabInstance(): Router<TabMessages, void> {
+    return new Router();
+  }
+
+  private isRegistered(type: keyof M): boolean {
     return this.handlers.has(type) || this.passiveHandlers.has(type);
   }
 
-  add<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
+  add<T extends Exclude<keyof M, RegisteredTypes>>(
     type: T,
-    handler: Handler<T>,
-  ): Router<Exclude<RegisteredTypes | T, void>> {
+    handler: MHandler<M, T>,
+  ): Router<M, Exclude<RegisteredTypes | T, void>> {
     if (this.isRegistered(type))
-      throw Error(`Already registered: type=${type}`);
-    this.handlers.set(type, handler as unknown as Handler<keyof AllMessages>);
+      throw Error(`Already registered: type=${String(type)}`);
+    this.handlers.set(type, handler);
     return this;
   }
 
   // Register a passive handler: observes the message without sending a
   // response. Use when another listener in a different script (e.g.
   // content-root.ts) owns the sendResponse for this message type.
-  addPassive<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
+  addPassive<T extends Exclude<keyof M, RegisteredTypes>>(
     type: T,
-    handler: PassiveHandler<T>,
-  ): Router<Exclude<RegisteredTypes | T, void>> {
+    handler: MPassiveHandler<M, T>,
+  ): Router<M, Exclude<RegisteredTypes | T, void>> {
     if (this.isRegistered(type))
-      throw Error(`Already registered: type=${type}`);
-    this.passiveHandlers.set(
-      type,
-      handler as unknown as PassiveHandler<keyof AllMessages>,
-    );
+      throw Error(`Already registered: type=${String(type)}`);
+    this.passiveHandlers.set(type, handler);
     return this;
   }
 
-  addAll<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
-    types: T[],
-    buildHandler: (type: T) => Handler<T>,
-  ): Router<Exclude<RegisteredTypes | T, void>> {
-    types.forEach((type) => this.add(type, buildHandler(type)));
-    return this;
-  }
-
-  merge<T extends Exclude<keyof AllMessages, RegisteredTypes>>(
-    router: Router<T>,
-  ): Router<Exclude<RegisteredTypes | T, void>> {
+  // M is fixed on the router, so merge only accepts routers of the same channel.
+  merge<T extends Exclude<keyof M, RegisteredTypes>>(
+    router: Router<M, T>,
+  ): Router<M, Exclude<RegisteredTypes | T, void>> {
     for (const [type, handler] of router.handlers) {
       this.handlers.set(type, handler);
     }
@@ -225,12 +215,14 @@ export class Router<
 
   // Returns true if the message is handled asynchronously.
   // See https://developer.chrome.com/docs/extensions/mv3/messaging/#simple.
-  private route<T extends keyof AllMessages>(
-    message: Message<T>,
+  private route<T extends keyof M>(
+    message: MMessage<M, T>,
     sender: chrome.runtime.MessageSender,
-    sendResponse: (arg: SendResponseArg<T>) => void,
+    sendResponse: (arg: MSendResponseArg<M, T>) => void,
   ): boolean | void {
-    const passiveHandler = this.passiveHandlers.get(type(message));
+    const msgType = (message as { "@type": keyof M })["@type"];
+
+    const passiveHandler = this.passiveHandlers.get(msgType);
     if (passiveHandler) {
       console.debug("Recieve (passive): ", message);
       try {
@@ -244,13 +236,13 @@ export class Router<
       return; // Do not call sendResponse; the active listener owns the response.
     }
 
-    const handler = this.handlers.get(type(message));
+    const handler = this.handlers.get(msgType);
     if (!handler) return;
 
     console.debug("Recieve: ", message);
     console.debug("Handle: ", handler);
 
-    let response: Response<T> | Promise<Response<T>> | undefined;
+    let response: MResponse<M, T> | Promise<MResponse<M, T>> | undefined;
     let error;
     try {
       response = handler(message, sender);
@@ -266,7 +258,7 @@ export class Router<
     } else if (error) {
       sendResponse(buildErrorArg(error));
     } else {
-      sendResponse({ response });
+      sendResponse({ response: response! });
     }
   }
 
@@ -275,9 +267,7 @@ export class Router<
   }
 }
 
-function buildErrorArg<T extends keyof AllMessages>(
-  error: unknown,
-): SendResponseArg<T> {
+function buildErrorArg(error: unknown): { error: Error } {
   if (error instanceof Error) {
     return { error };
   } else if (typeof error === "string") {
@@ -289,11 +279,13 @@ function buildErrorArg<T extends keyof AllMessages>(
 
 export async function sendToRuntime<T extends keyof RuntimeMessages>(
   type: T,
-  payload: RuntimeMessages[T]["payload"],
-): Promise<RuntimeMessages[T]["response"]> {
-  const r = await chrome.runtime.sendMessage<Message<T>, SendResponseArg<T>>(
-    message(type, payload),
-  );
+  payload: MPayload<RuntimeMessages, T>,
+): Promise<MResponse<RuntimeMessages, T>> {
+  const msg = makeMessage<RuntimeMessages, T>(type, payload);
+  const r = await chrome.runtime.sendMessage<
+    typeof msg,
+    { response: MResponse<RuntimeMessages, T> } | { error: Error }
+  >(msg);
   if (r == null)
     throw Error(
       `No response for ${type}: receiver missing or handler not registered`,
@@ -305,14 +297,14 @@ export async function sendToRuntime<T extends keyof RuntimeMessages>(
 export async function sendToTab<T extends keyof TabMessages>(
   tabId: number,
   type: T,
-  payload: TabMessages[T]["payload"],
+  payload: MPayload<TabMessages, T>,
   options: chrome.tabs.MessageSendOptions = {},
-): Promise<TabMessages[T]["response"]> {
-  const r = await chrome.tabs.sendMessage<Message<T>, SendResponseArg<T>>(
-    tabId,
-    message(type, payload),
-    options,
-  );
+): Promise<MResponse<TabMessages, T>> {
+  const msg = makeMessage<TabMessages, T>(type, payload);
+  const r = await chrome.tabs.sendMessage<
+    typeof msg,
+    { response: MResponse<TabMessages, T> } | { error: Error }
+  >(tabId, msg, options);
   if (r == null)
     throw Error(
       `No response for ${type}: receiver missing or handler not registered`,


### PR DESCRIPTION
## Summary

- Replaces the single flat `Messages` interface with `RuntimeMessages` (received by background SW) and `TabMessages` (received by content scripts), both kept inside `src/lib/chrome-messages.ts` to respect the `lib/` layer boundary.
- `Router` is now generic over the message map `M`: `Router<M, RegisteredTypes>`. `merge()` only accepts `Router<M, T>` with the same `M`, so background and content routers cannot be accidentally mixed at compile time.
- `newRuntimeInstance()` returns `Router<RuntimeMessages, void>`; `newTabInstance()` returns `Router<TabMessages, void>`.
- `sendToRuntime` is constrained to `keyof RuntimeMessages`; `sendToTab` to `keyof TabMessages`.
- `AllMessages` intersection type is gone; conditional inference types (`MPayload`/`MResponse`) are used throughout so concrete interfaces work without index signatures.
- `addAll` removed (unused after the hinter refactor).
- Renames the 2-hop relay types to have distinct per-channel names, following the existing `BlurUp`/`BlurRelay` precedent:
  - `AttachHints` / `HitHint` / `RemoveHints` — runtime hop names kept; tab-side dispatched hops renamed to `AttachHintsInTab` / `HitHintInTab` / `RemoveHintsInTab`.
  - `ExecuteAction` (runtime) → `ExecuteActionInFrame` (tab).
- Removes the `// TODO separate by the handler` comment.

Closes #98

## Test plan

- [x] `npm run lint` passes (ESLint + Prettier + tsc + changelog)
- [x] `npm run test` passes (88/88)
- [x] CI green (dry-build / test / e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)