### PR TITLE
Fix sticky-mode session interleaving: await RemoveHints before AttachHints

### DIFF
--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -1,8 +1,17 @@
 import { sendToRuntime } from "./chrome-messages";
 import type { SingleLetter } from "./strings";
 
+function noop() {
+  /* intentionally empty */
+}
+
 export default class HinterClient {
   private hinting: boolean;
+  // Resolves when the in-flight RemoveHints round-trip completes (always
+  // resolves, never rejects). attachHints() awaits this barrier before sending
+  // AttachHints so that RemoveHintsInTab always reaches content-root before
+  // AttachHintsInTab, preventing session interleaving.
+  private removeBarrier: Promise<void> | null = null;
 
   constructor() {
     this.hinting = false;
@@ -21,6 +30,10 @@ export default class HinterClient {
 
   async attachHints() {
     if (this.hinting) throw Error("Illegal state");
+    // Wait for any in-flight remove to finish so RemoveHintsInTab arrives at
+    // content-root before AttachHintsInTab. Without this, rapid action→sticky
+    // sequences can interleave sessions and silently drop hitHint calls.
+    if (this.removeBarrier) await this.removeBarrier;
     this.hinting = true;
     try {
       await sendToRuntime("AttachHints", undefined);
@@ -38,6 +51,8 @@ export default class HinterClient {
   async removeHints(options: ActionOptions, execute: boolean) {
     if (!this.hinting) throw Error("Illegal state");
     this.hinting = false;
-    await sendToRuntime("RemoveHints", { options, execute });
+    const p = sendToRuntime("RemoveHints", { options, execute });
+    this.removeBarrier = p.then(noop, noop);
+    await p;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the flaky E2E test `test/e2e/iframe-blur-cycle.spec.ts` — `hint action works after focus-blur-focus cycle on iframe element`.

**Root cause**: When the user fires action-key then sticky-key in rapid succession, `hinterClient.removeHints()` and `hinterClient.attachHints()` are both invoked fire-and-forget by the keyboard handler. Due to async message hops (content-all → background → content-root), `RemoveHintsInTab` could arrive at content-root *after* `AttachHintsInTab`.

When that race occurs, the stale remove call sees the second session's context as the active context, clears it (`this.context = null`), removes hints from the DOM, and signals `"Complete"` to the second session's aggregation loop — all before any hint-key input is processed. Subsequent `hitHint` calls throw `"hinting not started"` and are silently caught, leaving `data-state` untouched. The test observes 0 `.hint[data-state='hit']` elements.

**Fix** (`src/lib/hinter-client.ts`): Store the `RemoveHints` round-trip promise as a `removeBarrier`. `attachHints()` awaits it before sending `AttachHints`, guaranteeing that `RemoveHintsInTab` is fully processed by content-root before `AttachHintsInTab` arrives. No arbitrary sleeps; no test-only patches.

## Test plan

- [ ] `npm run lint && npm run test` — all unit tests pass
- [ ] `npx playwright test test/e2e/iframe-blur-cycle.spec.ts` — run several times; no flakiness
- [ ] CI green on all jobs

Closes #110