### PR TITLE
chore(lint): satisfy require-comment-rationale in src/content-all

### DIFF
--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -89,9 +89,12 @@ chrome.runtime.onMessage.addListener(
     .add("BlurRelay", ({ childFrameId, rect }) => {
       blurer.handleBlurRelay(childFrameId, rect);
     })
-    // Passively observe AttachHintsInTab/RemoveHintsInTab forwarded to the root frame
-    // (frameId:0). Keeps the root frame's keyboard handler in sync when a
-    // child frame initiated the hint session. content-root.ts owns sendResponse.
+    /**
+     * WHY: passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
+     * the root frame (frameId:0). Keeps the root frame's keyboard handler in
+     * sync when a child frame initiated the hint session. content-root.ts
+     * owns sendResponse.
+     */
     .addPassive("AttachHintsInTab", () => hinterClient.syncHinting(true))
     .addPassive("RemoveHintsInTab", () => hinterClient.syncHinting(false))
     .buildListener(),

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -89,12 +89,10 @@ chrome.runtime.onMessage.addListener(
     .add("BlurRelay", ({ childFrameId, rect }) => {
       blurer.handleBlurRelay(childFrameId, rect);
     })
-    /**
-     * Passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
-     * the root frame (frameId:0). Keeps the root frame's keyboard handler in
-     * sync when a child frame initiated the hint session. content-root.ts
-     * owns sendResponse.
-     */
+    /* WHY: passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
+       the root frame (frameId:0). Keeps the root frame's keyboard handler in
+       sync when a child frame initiated the hint session. content-root.ts
+       owns sendResponse. */
     .addPassive("AttachHintsInTab", () => hinterClient.syncHinting(true))
     .addPassive("RemoveHintsInTab", () => hinterClient.syncHinting(false))
     .buildListener(),

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -90,7 +90,7 @@ chrome.runtime.onMessage.addListener(
       blurer.handleBlurRelay(childFrameId, rect);
     })
     /**
-     * WHY: passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
+     * Passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
      * the root frame (frameId:0). Keeps the root frame's keyboard handler in
      * sync when a child frame initiated the hint session. content-root.ts
      * owns sendResponse.

--- a/src/content-all/action-handlers.ts
+++ b/src/content-all/action-handlers.ts
@@ -94,10 +94,6 @@ HANDLERS.push({
   },
 });
 
-// -----------------------------------------
-// Element Class Specific Handlers
-// -----------------------------------------
-
 HANDLERS.push({
   getDescriptions() {
     return {
@@ -121,7 +117,6 @@ const CLICKABLE_INPUT_TYPES = new Set([
   "reset",
 ]);
 
-// input elements for clickable types.
 HANDLERS.push({
   getDescriptions() {
     return {
@@ -141,7 +136,6 @@ HANDLERS.push({
   },
 });
 
-// input elements exclude clickable types.
 HANDLERS.push({
   getDescriptions() {
     return {
@@ -160,7 +154,7 @@ HANDLERS.push({
     try {
       target.showPicker();
     } catch {
-      // NotAllowedError when the frame lacks user activation; focus is enough.
+      // WHY: NotAllowedError when the frame lacks user activation; focus is enough.
     }
   },
 });
@@ -212,15 +206,11 @@ HANDLERS.push({
       try {
         target.showPicker();
       } catch {
-        // NotAllowedError when the frame lacks user activation; focus is enough.
+        // WHY: NotAllowedError when the frame lacks user activation; focus is enough.
       }
     }
   },
 });
-
-// -----------------------------------------
-// /Element Class Specific Handlers
-// -----------------------------------------
 
 const CLICKABLE_SELECTORS = [
   "a[*|href]",
@@ -230,7 +220,7 @@ const CLICKABLE_SELECTORS = [
   "[onmousedown]",
   "[onmouseup]",
 
-  // See https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles
+  // WHY: see https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles
   "[role=link]",
   "[role=button]",
   "[role=checkbox]",
@@ -352,7 +342,7 @@ HANDLERS.push({
       return;
     }
 
-    // Make scrollable it with your keyboard.
+    // WHY: make scrollable it with your keyboard.
     if (!element.hasAttribute("tabindex")) {
       element.setAttribute("tabindex", "-1");
       element.addEventListener(

--- a/src/content-all/blurer-client.ts
+++ b/src/content-all/blurer-client.ts
@@ -3,7 +3,7 @@ import { getBoundingClientRect } from "../dom/elements";
 import { printError } from "../lib/errors";
 import { FrameRegistry } from "./frame-registration";
 
-// Sends BlurUp to background, which relays it toward the root frame.
+// WHY: sends BlurUp to background, which relays it toward the root frame.
 export default class Blur {
   constructor(private readonly frameRegistry: FrameRegistry) {}
 
@@ -14,7 +14,7 @@ export default class Blur {
     this.frameRegistry.parentFrameId
       .then((parentFrameId) => {
         if (parentFrameId == null) {
-          // Root frame: send directly to BlurRoot via parentFrameId 0.
+          // WHY: root frame: send directly to BlurRoot via parentFrameId 0.
           return sendToRuntime("BlurUp", { parentFrameId: 0, rect });
         }
         return sendToRuntime("BlurUp", { parentFrameId, rect });

--- a/src/content-all/blurer-client.ts
+++ b/src/content-all/blurer-client.ts
@@ -3,7 +3,7 @@ import { getBoundingClientRect } from "../dom/elements";
 import { printError } from "../lib/errors";
 import { FrameRegistry } from "./frame-registration";
 
-// WHY: sends BlurUp to background, which relays it toward the root frame.
+/** Sends BlurUp to background, which relays it toward the root frame. */
 export default class Blur {
   constructor(private readonly frameRegistry: FrameRegistry) {}
 

--- a/src/content-all/blurer.ts
+++ b/src/content-all/blurer.ts
@@ -7,7 +7,7 @@ import { FrameRegistry } from "./frame-registration";
 export class BlurerContentAll {
   constructor(private readonly frameRegistry: FrameRegistry) {}
 
-  // Handles BlurRelay from background: transform rect to parent coords and send BlurUp.
+  // WHY: handles BlurRelay from background: transform rect to parent coords and send BlurUp.
   handleBlurRelay(
     childFrameId: number,
     rectJson: RectJSON<"element-border", "layout-viewport"> | null,
@@ -18,7 +18,7 @@ export class BlurerContentAll {
       return;
     }
     if (!frame.isConnected) {
-      // The iframe was removed from DOM; its entry will be ignored next lookup.
+      // WHY: the iframe was removed from DOM; its entry will be ignored next lookup.
       console.debug("BlurRelay: iframe no longer connected, skipping", frame);
       return;
     }

--- a/src/content-all/blurer.ts
+++ b/src/content-all/blurer.ts
@@ -7,7 +7,7 @@ import { FrameRegistry } from "./frame-registration";
 export class BlurerContentAll {
   constructor(private readonly frameRegistry: FrameRegistry) {}
 
-  // WHY: handles BlurRelay from background: transform rect to parent coords and send BlurUp.
+  /** Handles BlurRelay from background: transform rect to parent coords and send BlurUp. */
   handleBlurRelay(
     childFrameId: number,
     rectJson: RectJSON<"element-border", "layout-viewport"> | null,

--- a/src/content-all/frame-registration.ts
+++ b/src/content-all/frame-registration.ts
@@ -104,28 +104,24 @@ export class FrameRegistry {
       | undefined;
 
     if (data?.["@type"] === ANNOUNCEMENT_TYPE) {
-      /**
-       * MessageEventSource is Window | MessagePort | ServiceWorker.
-       * Duck-type via `"window" in source`: `window` is on the cross-origin
-       * property allowlist (so `in` never throws SecurityError), and only
-       * Window has it, MessagePort and ServiceWorker do not. Avoids
-       * `instanceof ServiceWorker`, which throws ReferenceError in insecure
-       * contexts (http).
-       */
+      /* WHY: MessageEventSource is Window | MessagePort | ServiceWorker.
+         Duck-type via `"window" in source`: `window` is on the cross-origin
+         property allowlist (so `in` never throws SecurityError), and only
+         Window has it, MessagePort and ServiceWorker do not. Avoids
+         `instanceof ServiceWorker`, which throws ReferenceError in insecure
+         contexts (http). */
       const source = e.source;
       if (!source || !("window" in source)) return;
 
       const iframe = findIframeBySource(source);
       if (!iframe) {
-        /**
-         * Reachable in benign cases that we can't disambiguate from
-         * real misses: iframes inside closed shadow roots (unreachable via
-         * DOM walk), React remount races where `contentWindow` identity is
-         * lost mid-handshake, iframe removed mid-flight, src swap, bfcache
-         * revival. `source.parent === window` doesn't reliably indicate a
-         * real miss either, since the first two cases also satisfy it. Log
-         * at debug only.
-         */
+        /* WHY: reachable in benign cases that we can't disambiguate from
+           real misses: iframes inside closed shadow roots (unreachable via
+           DOM walk), React remount races where `contentWindow` identity is
+           lost mid-handshake, iframe removed mid-flight, src swap, bfcache
+           revival. `source.parent === window` doesn't reliably indicate a
+           real miss either, since the first two cases also satisfy it. Log
+           at debug only. */
         console.debug("FrameIdAnnouncement from unknown source:", source);
         return;
       }

--- a/src/content-all/frame-registration.ts
+++ b/src/content-all/frame-registration.ts
@@ -2,18 +2,21 @@ import { listIframesInShadowRoots } from "../dom/elements";
 import { sendToRuntime } from "../lib/chrome-messages";
 import { printError } from "../lib/errors";
 
-// Locate the iframe element whose contentWindow is `source`.
-// Tiered to avoid a full DOM walk in the common case:
-//   0. `source.closed` — skip everything for dead windows (stale messages from
-//      removed iframes / bfcache); no point scanning the DOM for a corpse.
-//   1. `source.frameElement` — O(1), reaches through shadow boundaries when
-//      same-origin. `frameElement` is NOT on the cross-origin property
-//      allowlist, so reading it on a cross-origin Window throws SecurityError;
-//      swallow and fall through to the DOM-side lookup.
-//   2. Live light-DOM HTMLCollection — covers cross-origin iframes that live
-//      in the light DOM (the typical ad/embed case).
-//   3. Shadow-root walk — last resort for the rare cross-origin iframe that
-//      is hosted inside a shadow tree.
+/**
+ * WHY: locates the iframe element whose contentWindow is `source`, tiered to
+ * avoid a full DOM walk in the common case:
+ *   0. `source.closed`: skip everything for dead windows (stale messages
+ *      from removed iframes / bfcache); no point scanning the DOM for a
+ *      corpse.
+ *   1. `source.frameElement`: O(1), reaches through shadow boundaries when
+ *      same-origin. `frameElement` is NOT on the cross-origin property
+ *      allowlist, so reading it on a cross-origin Window throws
+ *      SecurityError; swallow and fall through to the DOM-side lookup.
+ *   2. Live light-DOM HTMLCollection: covers cross-origin iframes that live
+ *      in the light DOM (the typical ad/embed case).
+ *   3. Shadow-root walk: last resort for the rare cross-origin iframe that
+ *      is hosted inside a shadow tree.
+ */
 function findIframeBySource(source: Window): HTMLIFrameElement | undefined {
   if (source.closed) return undefined;
 
@@ -21,7 +24,7 @@ function findIframeBySource(source: Window): HTMLIFrameElement | undefined {
     const direct = source.frameElement;
     if (direct?.tagName === "IFRAME") return direct as HTMLIFrameElement;
   } catch {
-    // cross-origin source: frameElement access throws; fall through.
+    // WHY: cross-origin source, frameElement access throws; fall through.
   }
 
   for (const iframe of document.getElementsByTagName("iframe")) {
@@ -48,10 +51,13 @@ interface ParentFrameIdResponse {
   parentFrameId: number;
 }
 
-// Tracks child iframe ↔ frameId mappings via postMessage handshake and resolves
-// this frame's parentFrameId. The only place in the codebase that still uses
-// window.postMessage cross-frame, because frameId is needed before any
-// chrome.runtime relay can address the parent/child by frameId.
+/**
+ * WHY: the only place in the codebase that still uses window.postMessage
+ * cross-frame, because frameId is needed before any chrome.runtime relay can
+ * address the parent/child by frameId. Tracks child iframe to frameId
+ * mappings via postMessage handshake and resolves this frame's
+ * parentFrameId.
+ */
 export class FrameRegistry {
   private readonly iframeByFrameId = new Map<number, HTMLIFrameElement>();
   private readonly iframeToFrameId = new Map<HTMLIFrameElement, number>();
@@ -71,7 +77,7 @@ export class FrameRegistry {
               "@type": ANNOUNCEMENT_TYPE,
               frameId,
             } satisfies FrameIdAnnouncement,
-            "*", // intentional: avoids silent drop if the parent navigates mid-flight.
+            "*", // WHY: intentional, avoids silent drop if the parent navigates mid-flight.
           );
         })
         .catch(printError);
@@ -98,22 +104,28 @@ export class FrameRegistry {
       | undefined;
 
     if (data?.["@type"] === ANNOUNCEMENT_TYPE) {
-      // MessageEventSource = Window | MessagePort | ServiceWorker.
-      // Duck-type via `"window" in source`: `window` is on the cross-origin
-      // property allowlist (so `in` never throws SecurityError), and only Window
-      // has it — MessagePort and ServiceWorker do not. Avoids `instanceof
-      // ServiceWorker`, which throws ReferenceError in insecure contexts (http).
+      /**
+       * WHY: MessageEventSource is Window | MessagePort | ServiceWorker.
+       * Duck-type via `"window" in source`: `window` is on the cross-origin
+       * property allowlist (so `in` never throws SecurityError), and only
+       * Window has it, MessagePort and ServiceWorker do not. Avoids
+       * `instanceof ServiceWorker`, which throws ReferenceError in insecure
+       * contexts (http).
+       */
       const source = e.source;
       if (!source || !("window" in source)) return;
 
       const iframe = findIframeBySource(source);
       if (!iframe) {
-        // Reachable in benign cases that we can't disambiguate from real misses:
-        // iframes inside closed shadow roots (unreachable via DOM walk), React
-        // remount races where `contentWindow` identity is lost mid-handshake,
-        // iframe removed mid-flight, src swap, bfcache revival. `source.parent
-        // === window` doesn't reliably indicate a real miss either, since the
-        // first two cases also satisfy it. Log at debug only.
+        /**
+         * WHY: reachable in benign cases that we can't disambiguate from
+         * real misses: iframes inside closed shadow roots (unreachable via
+         * DOM walk), React remount races where `contentWindow` identity is
+         * lost mid-handshake, iframe removed mid-flight, src swap, bfcache
+         * revival. `source.parent === window` doesn't reliably indicate a
+         * real miss either, since the first two cases also satisfy it. Log
+         * at debug only.
+         */
         console.debug("FrameIdAnnouncement from unknown source:", source);
         return;
       }
@@ -121,7 +133,7 @@ export class FrameRegistry {
       this.iframeByFrameId.set(data.frameId, iframe);
       this.iframeToFrameId.set(iframe, data.frameId);
 
-      // Reply with our own frameId so the child can store its parentFrameId.
+      // WHY: reply with our own frameId so the child can store its parentFrameId.
       this.myFrameIdPromise
         .then((parentFrameId) => {
           source.postMessage(

--- a/src/content-all/frame-registration.ts
+++ b/src/content-all/frame-registration.ts
@@ -3,7 +3,7 @@ import { sendToRuntime } from "../lib/chrome-messages";
 import { printError } from "../lib/errors";
 
 /**
- * WHY: locates the iframe element whose contentWindow is `source`, tiered to
+ * Locates the iframe element whose contentWindow is `source`, tiered to
  * avoid a full DOM walk in the common case:
  *   0. `source.closed`: skip everything for dead windows (stale messages
  *      from removed iframes / bfcache); no point scanning the DOM for a
@@ -52,7 +52,7 @@ interface ParentFrameIdResponse {
 }
 
 /**
- * WHY: the only place in the codebase that still uses window.postMessage
+ * The only place in the codebase that still uses window.postMessage
  * cross-frame, because frameId is needed before any chrome.runtime relay can
  * address the parent/child by frameId. Tracks child iframe to frameId
  * mappings via postMessage handshake and resolves this frame's
@@ -105,7 +105,7 @@ export class FrameRegistry {
 
     if (data?.["@type"] === ANNOUNCEMENT_TYPE) {
       /**
-       * WHY: MessageEventSource is Window | MessagePort | ServiceWorker.
+       * MessageEventSource is Window | MessagePort | ServiceWorker.
        * Duck-type via `"window" in source`: `window` is on the cross-origin
        * property allowlist (so `in` never throws SecurityError), and only
        * Window has it, MessagePort and ServiceWorker do not. Avoids
@@ -118,7 +118,7 @@ export class FrameRegistry {
       const iframe = findIframeBySource(source);
       if (!iframe) {
         /**
-         * WHY: reachable in benign cases that we can't disambiguate from
+         * Reachable in benign cases that we can't disambiguate from
          * real misses: iframes inside closed shadow roots (unreachable via
          * DOM walk), React remount races where `contentWindow` identity is
          * lost mid-handshake, iframe removed mid-flight, src swap, bfcache

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -5,7 +5,6 @@ import { isEditable } from "../dom/elements";
 import { isSingleLetter } from "../lib/strings";
 import { printError } from "../lib/errors";
 
-// TODO: Factor out the blurer and then rename this class.
 export class KeyboardHandlerContentAll {
   private hitMatcher: KeyHoldMatcher | null = null;
   private blurMatcher: KeyHoldMatcher | null = null;
@@ -14,8 +13,10 @@ export class KeyboardHandlerContentAll {
   private cancelMatcher: KeyHoldMatcher | null = null;
   private hintLetters = "";
   private matchedBlacklist: string[] = [];
-  // true when hints were attached by magic key hold (fires on keyup);
-  // false when attached by sticky key (fires only via actionKey/cancelKey).
+  /**
+   * WHY: true when hints were attached by magic key hold (fires on keyup);
+   * false when attached by sticky key (fires only via actionKey/cancelKey).
+   */
   private holdHinting = false;
 
   constructor(
@@ -54,7 +55,6 @@ export class KeyboardHandlerContentAll {
     this.matchedBlacklist = matchedBlacklist;
   }
 
-  // Reset the held-key history of every matcher.
   private resetMatchers() {
     this.hitMatcher?.reset();
     this.blurMatcher?.reset();
@@ -63,7 +63,7 @@ export class KeyboardHandlerContentAll {
     this.cancelMatcher?.reset();
   }
 
-  // Return true if the event is handled.
+  // INVARIANT: returns true if the event is handled.
   handleKeydown(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keydown(event);
     const blurMatcher = this.blurMatcher?.keydown(event);
@@ -117,7 +117,7 @@ export class KeyboardHandlerContentAll {
     return false;
   }
 
-  // Return true if the event is handled.
+  // INVARIANT: returns true if the event is handled.
   handleKeyup(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keyup(event);
     this.blurMatcher?.keyup(event);
@@ -140,18 +140,22 @@ export class KeyboardHandlerContentAll {
     return false;
   }
 
-  // End the current hint session. Resetting the matchers clears any key left
-  // "held" in their history because its keyup was lost — e.g. an Action Key
-  // that fired a target=_blank action and opened a new tab, stealing focus
-  // before keyup arrived. Without this, the stuck key would spuriously match on
-  // the next session.
+  /**
+   * WHY: resetting the matchers clears any key left "held" in their history
+   * because its keyup was lost, e.g. an Action Key that fired a
+   * target=_blank action and opened a new tab, stealing focus before keyup
+   * arrived. Without this, the stuck key would spuriously match on the next
+   * session.
+   */
   private endSession() {
     this.holdHinting = false;
     this.resetMatchers();
   }
 
-  // Just hijack the event when hinting.
-  // Return true if the event is handled.
+  /**
+   * WHY: just hijacks the event when hinting.
+   * INVARIANT: returns true if the event is handled.
+   */
   handleKeypress() {
     return this.hinter.isHinting;
   }

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -63,7 +63,7 @@ export class KeyboardHandlerContentAll {
     this.cancelMatcher?.reset();
   }
 
-  // INVARIANT: returns true if the event is handled.
+  /** Returns true if the event is handled. */
   handleKeydown(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keydown(event);
     const blurMatcher = this.blurMatcher?.keydown(event);
@@ -117,7 +117,7 @@ export class KeyboardHandlerContentAll {
     return false;
   }
 
-  // INVARIANT: returns true if the event is handled.
+  /** Returns true if the event is handled. */
   handleKeyup(event: KeyboardEvent): boolean {
     const hitMatcher = this.hitMatcher?.keyup(event);
     this.blurMatcher?.keyup(event);

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -14,7 +14,7 @@ export class KeyboardHandlerContentAll {
   private hintLetters = "";
   private matchedBlacklist: string[] = [];
   /**
-   * WHY: true when hints were attached by magic key hold (fires on keyup);
+   * True when hints were attached by magic key hold (fires on keyup);
    * false when attached by sticky key (fires only via actionKey/cancelKey).
    */
   private holdHinting = false;
@@ -141,7 +141,7 @@ export class KeyboardHandlerContentAll {
   }
 
   /**
-   * WHY: resetting the matchers clears any key left "held" in their history
+   * Resetting the matchers clears any key left "held" in their history
    * because its keyup was lost, e.g. an Action Key that fired a
    * target=_blank action and opened a new tab, stealing focus before keyup
    * arrived. Without this, the stuck key would spuriously match on the next
@@ -153,8 +153,8 @@ export class KeyboardHandlerContentAll {
   }
 
   /**
-   * WHY: just hijacks the event when hinting.
-   * INVARIANT: returns true if the event is handled.
+   * Just hijacks the event when hinting.
+   * Returns true if the event is handled.
    */
   handleKeypress() {
     return this.hinter.isHinting;

--- a/src/content-all/rect-aggregator.ts
+++ b/src/content-all/rect-aggregator.ts
@@ -140,9 +140,11 @@ export class RectAggregatorContentAll {
       return;
     }
 
-    // Poll until the child frame has completed its FrameIdAnnouncement handshake.
-    // Under CI load the postMessage round-trip can arrive after AllRectsRequest
-    // fan-out, so wait up to 300 ms before giving up.
+    /**
+     * WHY: polls until the child frame has completed its FrameIdAnnouncement
+     * handshake. Under CI load the postMessage round-trip can arrive after
+     * AllRectsRequest fan-out, so wait up to 300 ms before giving up.
+     */
     let childFrameId = this.frameRegistry.getFrameId(frame);
     if (childFrameId == null) {
       for (let i = 0; i < 30; i++) {
@@ -194,7 +196,6 @@ export class RectAggregatorContentAll {
   }
 }
 
-// Bond rects if they have same actual target.
 function bondByActualTarget(
   elementProfiles: ElementProfile[],
 ): ElementProfile[] {

--- a/src/content-all/rect-aggregator.ts
+++ b/src/content-all/rect-aggregator.ts
@@ -140,11 +140,9 @@ export class RectAggregatorContentAll {
       return;
     }
 
-    /**
-     * Polls until the child frame has completed its FrameIdAnnouncement
-     * handshake. Under CI load the postMessage round-trip can arrive after
-     * AllRectsRequest fan-out, so wait up to 300 ms before giving up.
-     */
+    /* WHY: polls until the child frame has completed its FrameIdAnnouncement
+       handshake. Under CI load the postMessage round-trip can arrive after
+       AllRectsRequest fan-out, so wait up to 300 ms before giving up. */
     let childFrameId = this.frameRegistry.getFrameId(frame);
     if (childFrameId == null) {
       for (let i = 0; i < 30; i++) {

--- a/src/content-all/rect-aggregator.ts
+++ b/src/content-all/rect-aggregator.ts
@@ -141,7 +141,7 @@ export class RectAggregatorContentAll {
     }
 
     /**
-     * WHY: polls until the child frame has completed its FrameIdAnnouncement
+     * Polls until the child frame has completed its FrameIdAnnouncement
      * handshake. Under CI load the postMessage round-trip can arrive after
      * AllRectsRequest fan-out, so wait up to 300 ms before giving up.
      */

--- a/src/content-all/rect-detector-pointer-crawler.ts
+++ b/src/content-all/rect-detector-pointer-crawler.ts
@@ -37,7 +37,7 @@ export class PointerCrawler {
   }
 
   private *generatePoints(a: Area): Generator<[number, number]> {
-    // Naive implementation
+    // WHY: naive implementation
     for (let x = a.minX; x < a.maxX; x += this.stepPx) {
       for (let y = a.minY; y < a.maxY; y += this.stepPx) {
         yield [x, y];
@@ -83,7 +83,6 @@ export class PointerCrawler {
     let pointedElement = document.elementFromPoint(x, y);
     if (pointedElement == null) return null;
 
-    // Traverse into shadow DOMs
     const stack = [pointedElement];
     while (pointedElement.shadowRoot) {
       const elemementInShadow = pointedElement.shadowRoot.elementFromPoint(

--- a/src/content-all/rect-detector.ts
+++ b/src/content-all/rect-detector.ts
@@ -100,13 +100,11 @@ export class RectDetector {
       .get(element)
       .get("position")!
       .toString();
-    /**
-     * Fixed/sticky elements are positioned relative to the viewport (or
-     * a transformed ancestor), so parent-overflow cropping doesn't apply.
-     * We don't yet handle the "transform" property in an ancestor changing
-     * the containing block. See
-     * https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning
-     */
+    /* WHY: fixed/sticky elements are positioned relative to the viewport (or
+       a transformed ancestor), so parent-overflow cropping doesn't apply.
+       We don't yet handle the "transform" property in an ancestor changing
+       the containing block. See
+       https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning */
     if (elementPosition === "fixed" || elementPosition === "sticky")
       return rect;
 
@@ -221,10 +219,8 @@ function getAreaRects(
     ];
   }
   if (element.shape === "poly") {
-    /**
-     * Returns a rectangle that contains all points. We should use a
-     * convex hull algorithm to get a better rectangle.
-     */
+    /* WHY: returns a rectangle that contains all points. We should use a
+       convex hull algorithm to get a better rectangle. */
     const xs = coords.filter((_, i) => i % 2 === 0);
     const ys = coords.filter((_, i) => i % 2 === 1);
     const top = Math.min(...ys) + imgRect.y;

--- a/src/content-all/rect-detector.ts
+++ b/src/content-all/rect-detector.ts
@@ -7,9 +7,11 @@ import { Rect } from "../dom/rects";
 
 interface ElementRect {
   rect: Rect<"element-border", "layout-viewport">;
-  // Phantom rect is not originally in the DOM tree.
-  // For example, the clickable area of <area> is not in the DOM tree.
-  // phantom rect should be skipped that is pointable by pointer.
+  /**
+   * WHY: a phantom rect is not originally in the DOM tree (e.g. the clickable
+   * area of an <area> element), so it should skip the isPointable check that
+   * a real element would need.
+   */
   isPhantom?: boolean;
 }
 
@@ -55,25 +57,21 @@ export class RectDetector {
       ...flatMap(
         this.getClientRects(element),
         ({ rect, isPhantom }): Rect<"element-border", "actual-viewport">[] => {
-          // Too small
           if (isSmallRect(rect)) return [];
 
           timerEnd = this.timers.start("viewport intersection");
-          // out of viewport
           let croppedRect: Rect<"element-border", "layout-viewport"> | null =
             Rect.intersection("element-border", rect, this.viewport);
           timerEnd();
           if (!croppedRect || isSmallRect(croppedRect)) return [];
 
           timerEnd = this.timers.start("cropByParent");
-          // hidden by parent element overflow
           croppedRect = this.cropByParent(element, croppedRect);
           timerEnd();
           if (!croppedRect || isSmallRect(croppedRect)) return [];
 
           timerEnd = this.timers.start("isPointable");
-          // pointer can't reach to the element
-          // Phantom rect should be skipped that is pointable by pointer.
+          // WHY: a phantom rect is skipped from the real isPointable check.
           const isPointable =
             Boolean(isPhantom) || this.isPointable(element, croppedRect);
           timerEnd();
@@ -102,8 +100,13 @@ export class RectDetector {
       .get(element)
       .get("position")!
       .toString();
-    // TODO We need to support some case like "transform" property in ancestor.
-    // See https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning
+    /**
+     * WHY: fixed/sticky elements are positioned relative to the viewport (or
+     * a transformed ancestor), so parent-overflow cropping doesn't apply.
+     * We don't yet handle the "transform" property in an ancestor changing
+     * the containing block. See
+     * https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning
+     */
     if (elementPosition === "fixed" || elementPosition === "sticky")
       return rect;
 
@@ -190,7 +193,7 @@ function getAreaRects(
   }
 
   if (element.shape === "circle") {
-    // return a square that be inscribed in the circle
+    // WHY: return a square that be inscribed in the circle
     const [x, y, r] = coords;
     const d = r / Math.sqrt(2);
     return [
@@ -218,8 +221,10 @@ function getAreaRects(
     ];
   }
   if (element.shape === "poly") {
-    // return a rectangle that contains all points
-    // We should use a convex hull algorithm to get a better rectangle.
+    /**
+     * WHY: returns a rectangle that contains all points. We should use a
+     * convex hull algorithm to get a better rectangle.
+     */
     const xs = coords.filter((_, i) => i % 2 === 0);
     const ys = coords.filter((_, i) => i % 2 === 1);
     const top = Math.min(...ys) + imgRect.y;

--- a/src/content-all/rect-detector.ts
+++ b/src/content-all/rect-detector.ts
@@ -8,7 +8,7 @@ import { Rect } from "../dom/rects";
 interface ElementRect {
   rect: Rect<"element-border", "layout-viewport">;
   /**
-   * WHY: a phantom rect is not originally in the DOM tree (e.g. the clickable
+   * A phantom rect is not originally in the DOM tree (e.g. the clickable
    * area of an <area> element), so it should skip the isPointable check that
    * a real element would need.
    */
@@ -101,7 +101,7 @@ export class RectDetector {
       .get("position")!
       .toString();
     /**
-     * WHY: fixed/sticky elements are positioned relative to the viewport (or
+     * Fixed/sticky elements are positioned relative to the viewport (or
      * a transformed ancestor), so parent-overflow cropping doesn't apply.
      * We don't yet handle the "transform" property in an ancestor changing
      * the containing block. See
@@ -222,7 +222,7 @@ function getAreaRects(
   }
   if (element.shape === "poly") {
     /**
-     * WHY: returns a rectangle that contains all points. We should use a
+     * Returns a rectangle that contains all points. We should use a
      * convex hull algorithm to get a better rectangle.
      */
     const xs = coords.filter((_, i) => i % 2 === 0);


### PR DESCRIPTION
## Summary
- Prefix genuine WHY/INVARIANT rationale comments with the required keyword (or convert multi-line ones to JSDoc) in `src/content-all` and `src/content-all.ts`.
- Delete comments that only restated what the code already expresses (section dividers, TODO with no lasting rationale, paraphrases of the following line).
- No behavior changes.

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npx ast-grep scan src/content-all src/content-all.ts` reports 0 violations