### PR TITLE
chore(lint): satisfy require-comment-rationale in test/scripts/docs

### DIFF
--- a/docs/tests/hidden-iframe.html
+++ b/docs/tests/hidden-iframe.html
@@ -18,7 +18,7 @@
   }
 </style>
 
-<!-- The iframe starts visible so the child element can receive focus,
+<!-- WHY: the iframe starts visible so the child element can receive focus,
      then the test hides it to simulate a zero-rect scenario. -->
 <iframe id="child-iframe" src="hidden-iframe-child.html"></iframe>
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,7 +15,7 @@ export default defineConfig([
     ],
     languageOptions: {
       parserOptions: {
-        // https://typescript-eslint.io/packages/parser/#projectservice
+        // WHY: https://typescript-eslint.io/packages/parser/#projectservice
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,22 +8,17 @@ export default defineConfig({
   testDir: path.join(__dirname, "test/e2e"),
   fullyParallel: false,
   timeout: 30_000,
-  // Two known CI-only races remain after the gotoTest readiness fix (#95):
-  // 1. iframe-hint: the knaviReady wait in gotoTest now covers this.
-  // 2. iframe-blur-cycle: BLUR_KEY dispatches key events only; the async
-  //    blur chain (BlurUp→BlurRoot→activeElement.blur) can complete while
-  //    hint letters are being typed, splitting input across frames (#110).
-  // Retries absorb both without weakening assertions.
+  // WHY: retries absorb two known CI-only races (iframe-hint readiness fixed by gotoTest's wait; iframe-blur-cycle's async blur chain can still race input, see #95/#110) without weakening assertions.
   retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: "http://127.0.0.1:8787/tests/",
-    // Extension tests require a persistent context, set up per fixture.
+    // WHY: extension tests require a persistent context, set up per fixture.
   },
   projects: [
     {
       name: "chromium-extension",
       use: {
-        // Channel / headless config is handled in fixtures.ts launchPersistentContext.
+        // WHY: channel / headless config is handled in fixtures.ts launchPersistentContext.
       },
     },
   ],

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,7 +28,7 @@ const JS_ENTRIES = [
 const ICON_WIDTHS = [16, 48, 128];
 
 export interface BuildOptions {
-  // WHY: esbuild also auto-defines process.env.NODE_ENV to "production" when minification is enabled.
+  /** esbuild also auto-defines process.env.NODE_ENV to "production" when minification is enabled. */
   readonly minify?: boolean;
 }
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,29 +28,24 @@ const JS_ENTRIES = [
 const ICON_WIDTHS = [16, 48, 128];
 
 export interface BuildOptions {
-  // Enables esbuild minification. esbuild also auto-defines
-  // process.env.NODE_ENV to "production" when minification is enabled.
+  // WHY: esbuild also auto-defines process.env.NODE_ENV to "production" when minification is enabled.
   readonly minify?: boolean;
 }
 
 export async function build({
   minify = false,
 }: BuildOptions = {}): Promise<void> {
-  // Recreate the build directory from scratch (no incremental builds).
   rmSync(BUILD, { recursive: true, force: true });
   mkdirSync(BUILD, { recursive: true });
 
-  // manifest.json
   writeFileSync(path.join(BUILD, "manifest.json"), jsonizeManifest());
 
-  // Copy static assets (*.html, *.css).
   for (const file of readdirSync(SRC)) {
     if (file.endsWith(".html") || file.endsWith(".css")) {
       copyFileSync(path.join(SRC, file), path.join(BUILD, file));
     }
   }
 
-  // Generate icons from icon.svg and icon-disabled.svg at toolbar widths.
   const TOOLBAR_ICONS = ["icon", "icon-disabled"];
   for (const w of ICON_WIDTHS) {
     for (const name of TOOLBAR_ICONS) {
@@ -62,7 +57,6 @@ export async function build({
     }
   }
 
-  // Generate other PNGs from the remaining SVGs (width 40).
   const skip = new Set(TOOLBAR_ICONS.map((n) => `${n}.svg`));
   for (const file of readdirSync(SRC)) {
     if (file.endsWith(".svg") && !skip.has(file)) {
@@ -71,7 +65,6 @@ export async function build({
     }
   }
 
-  // Bundle JS entries with esbuild.
   await esbuild({
     entryPoints: JS_ENTRIES.map((e) => path.join(SRC, e)),
     outdir: BUILD,

--- a/scripts/lint_changelog.bash
+++ b/scripts/lint_changelog.bash
@@ -30,9 +30,7 @@ should_start_with_version_header() {
   fi
 }
 
-# The line right after the version header becomes the git tag subject (and
-# therefore the GitHub release title). Require a non-bullet digest line there
-# whenever bullets exist; otherwise the first bullet ends up as the title.
+# WHY: the line right after the version header becomes the git tag subject (GitHub release title), so require a non-bullet digest line there whenever bullets exist, or the first bullet becomes the title.
 should_have_digest_before_bullets() {
   local file="$1"
   local third

--- a/scripts/tag_for_release.bash
+++ b/scripts/tag_for_release.bash
@@ -4,6 +4,5 @@ set -euxo pipefail
 cd "$(dirname "$0")/.."
 
 v="$(scripts/version.ts)"
-# Strip the "# Version X.Y.Z" heading (and the blank line below it) so the
-# digest line becomes the tag subject / GitHub release title.
+# WHY: strip the "# Version X.Y.Z" heading (and the blank line below it) so the digest line becomes the tag subject / GitHub release title.
 sed -e '1d' -e '1{/^$/d;}' "./changelog/$v.md" | git tag -a "$v" -F -

--- a/scripts/zip.ts
+++ b/scripts/zip.ts
@@ -24,7 +24,6 @@ function addDir(zip: JSZip, dir: string, base: string): void {
 }
 
 async function main(): Promise<void> {
-  // Produce a minified production build before zipping.
   await build({ minify: true });
   const zip = new JSZip();
   addDir(zip, BUILD, BUILD);

--- a/test/content-all/blurer.test.ts
+++ b/test/content-all/blurer.test.ts
@@ -68,19 +68,19 @@ void describe("BlurerContentAll.handleBlurRelay", () => {
       source: fakeSource,
     } as MessageEvent);
 
-    // Clear GetFrameId messages recorded during registry setup.
+    // WHY: clear GetFrameId messages recorded during registry setup.
     sentToRuntime.length = 0;
 
     const blurer = new BlurerContentAll(registry);
     blurer.handleBlurRelay(5, null);
 
-    // Wait for the async sendToRuntime call.
+    // WHY: wait for the async sendToRuntime call.
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.equal(sentToRuntime.length, 1);
     const sent = sentToRuntime[0];
     assert.equal(sent.type, "BlurUp");
-    // null rect must be forwarded, not swallowed
+    // INVARIANT: null rect must be forwarded, not swallowed
     assert.equal((sent.payload as Record<string, unknown>).rect, null);
   });
 
@@ -88,7 +88,7 @@ void describe("BlurerContentAll.handleBlurRelay", () => {
     const registry = makeRegistry();
 
     const fakeSource = { window: {} } as unknown as Window;
-    // getClientRects returns an empty iterable (zero-size / display:none iframe).
+    // WHY: getClientRects returns an empty iterable (zero-size / display:none iframe).
     const fakeIframe = {
       tagName: "IFRAME",
       contentWindow: fakeSource,

--- a/test/content-all/frame-registration.test.ts
+++ b/test/content-all/frame-registration.test.ts
@@ -32,7 +32,7 @@ setParent(fakeWindow);
 const { FrameRegistry } =
   await import("../../src/content-all/frame-registration.js");
 
-// Duck-type via `"window" in source` to identify a Window source.
+// WHY: duck-type via `"window" in source` to identify a Window source.
 function makeWindowSource(
   onPostMessage?: (data: unknown, origin: string) => void,
 ): Window {
@@ -53,7 +53,7 @@ void describe("FrameRegistry — announcement to parent", () => {
   });
 
   void test("no-ops when running in the root frame", async () => {
-    setParent(fakeWindow); // parent === window
+    setParent(fakeWindow); // WHY: parent === window signals the root frame
     new FrameRegistry();
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.equal(postedMessages.length, 0);
@@ -195,7 +195,7 @@ void describe("FrameRegistry — parentFrameId resolution", () => {
   });
 
   void test("resolves to undefined in root frame", async () => {
-    setParent(fakeWindow); // parent === window → root frame
+    setParent(fakeWindow); // WHY: parent === window → root frame
     const registry = new FrameRegistry();
     const result = await registry.parentFrameId;
     assert.equal(result, undefined);
@@ -206,7 +206,7 @@ void describe("FrameRegistry — parentFrameId resolution", () => {
       postMessage: (data: unknown, targetOrigin: string) =>
         postedMessages.push({ target: "parent", data, targetOrigin }),
     };
-    setParent(fakeParent); // non-root frame
+    setParent(fakeParent); // WHY: distinct from window, so this simulates a non-root frame
 
     const registry = new FrameRegistry();
 
@@ -246,7 +246,7 @@ void describe("FrameRegistry — parentFrameId resolution", () => {
       source: fakeParent,
     } as unknown as MessageEvent;
     registry.handleMessage(firstMsg);
-    registry.handleMessage(secondMsg); // ignored: Promise already resolved to 100
+    registry.handleMessage(secondMsg); // INVARIANT: ignored, Promise already resolved to 100
 
     const result = await registry.parentFrameId;
     assert.equal(result, 100);

--- a/test/content-all/frame-registration.test.ts
+++ b/test/content-all/frame-registration.test.ts
@@ -32,7 +32,7 @@ setParent(fakeWindow);
 const { FrameRegistry } =
   await import("../../src/content-all/frame-registration.js");
 
-// WHY: duck-type via `"window" in source` to identify a Window source.
+/** Duck-type via `"window" in source` to identify a Window source. */
 function makeWindowSource(
   onPostMessage?: (data: unknown, origin: string) => void,
 ): Window {

--- a/test/content-root/blurer.test.ts
+++ b/test/content-root/blurer.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-// BlurerContentRoot is loaded in the root frame only.
+// WHY: BlurerContentRoot is loaded in the root frame only, so parent === window here.
 (globalThis as Record<string, unknown>).parent = globalThis;
 (globalThis as Record<string, unknown>).window = globalThis;
 

--- a/test/dom/elements.test.ts
+++ b/test/dom/elements.test.ts
@@ -1,7 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-// WHY: patch globals before importing the module so instanceof checks work in Node.js.
 /* eslint-disable @typescript-eslint/no-empty-function */
 class FakeInput implements EventTarget {
   type = "text";
@@ -23,6 +22,7 @@ class FakeTextarea implements EventTarget {
   removeEventListener() {}
 }
 /* eslint-enable @typescript-eslint/no-empty-function */
+// WHY: patch globals before importing the module so instanceof checks work in Node.js.
 (globalThis as Record<string, unknown>).HTMLInputElement = FakeInput;
 (globalThis as Record<string, unknown>).HTMLTextAreaElement = FakeTextarea;
 

--- a/test/dom/elements.test.ts
+++ b/test/dom/elements.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-// Patch globals before importing the module so instanceof checks work in Node.js.
+// WHY: patch globals before importing the module so instanceof checks work in Node.js.
 /* eslint-disable @typescript-eslint/no-empty-function */
 class FakeInput implements EventTarget {
   type = "text";
@@ -26,7 +26,6 @@ class FakeTextarea implements EventTarget {
 (globalThis as Record<string, unknown>).HTMLInputElement = FakeInput;
 (globalThis as Record<string, unknown>).HTMLTextAreaElement = FakeTextarea;
 
-// Import after patching globals.
 const { isEditable } = await import("../../src/dom/elements.js");
 
 function input(overrides: Partial<FakeInput> = {}): EventTarget {

--- a/test/e2e/blur.spec.ts
+++ b/test/e2e/blur.spec.ts
@@ -72,22 +72,19 @@ test.describe("blur", () => {
   }) => {
     await gotoTest(page, "hidden-iframe.html");
 
-    // The iframe starts visible. Click the input to focus it.
     const childFrame = page.frameLocator("#child-iframe");
     const input = childFrame.locator("#hidden-input");
     await input.click();
     await expect(input).toBeFocused();
 
-    // Now hide the iframe so its content rect disappears (simulates an
-    // invisible iframe whose focused element can still intercept keys).
+    // WHY: hide the iframe so its content rect disappears, simulating an invisible iframe whose focused element can still intercept keys.
     await page.evaluate(() => {
       document.getElementById("child-iframe")?.classList.add("hidden");
     });
 
-    // Press blur key from the root frame.
     await page.keyboard.press("Escape");
 
-    // The input must lose focus even though the iframe has no visible rect.
+    // INVARIANT: the input must lose focus even though the iframe has no visible rect.
     const rawFrame = page
       .frames()
       .find((f) => f.url().includes("hidden-iframe-child"));

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -25,8 +25,7 @@ export const test = base.extend<Fixtures>({
   context: async ({}, use) => {
     const userDataDir = mkdtempSync(path.join(tmpdir(), "knavi-e2e-"));
     const ctx = await chromium.launchPersistentContext(userDataDir, {
-      // headless: true sets the old --headless flag which blocks extensions.
-      // Pass --headless=new directly so extensions (and the service worker) work.
+      // HACK: headless: true sets the old --headless flag which blocks extensions, so pass --headless=new directly instead so extensions (and the service worker) work.
       headless: false,
       args: [
         "--headless=new",
@@ -34,7 +33,7 @@ export const test = base.extend<Fixtures>({
         `--load-extension=${BUILD}`,
       ],
     });
-    // Wait for the service worker to start (confirms extension is loaded).
+    // WHY: wait for the service worker to start (confirms extension is loaded).
     if (ctx.serviceWorkers().length === 0) {
       await ctx.waitForEvent("serviceworker", { timeout: 10_000 });
     }
@@ -52,10 +51,6 @@ export const test = base.extend<Fixtures>({
 
 export { expect };
 
-// ---------------------------------------------------------------------------
-// Helpers shared across specs
-// ---------------------------------------------------------------------------
-
 /**
  * Set extension settings via the background service worker.
  * Only pass the keys you want to change; others remain untouched.
@@ -65,7 +60,7 @@ export async function setSettings(
   settings: Record<string, string>,
 ): Promise<void> {
   const sw = context.serviceWorkers()[0];
-  // chrome is available at runtime in the service worker; not known to TS here.
+  // WHY: chrome is available at runtime in the service worker; not known to TS here.
   await sw.evaluate(
     (s) =>
       new Promise<void>((resolve) => {
@@ -92,12 +87,11 @@ export async function setSettings(
 export async function gotoTest(page: Page, name: string): Promise<void> {
   await page.goto(name);
   await page.waitForLoadState("load");
-  // Wait for the root frame's content-all script to finish setting up.
   await page.waitForFunction(
     () => document.documentElement.dataset.knaviReady === "1",
     { timeout: 10_000 },
   );
-  // Click the body to ensure keyboard focus is on the page.
+  // WHY: click the body to ensure keyboard focus is on the page.
   await page.locator("body").click({ position: { x: 1, y: 1 } });
 }
 
@@ -107,7 +101,7 @@ export async function gotoTest(page: Page, name: string): Promise<void> {
  */
 export async function attachHints(page: Page): Promise<void> {
   await page.keyboard.down("Space");
-  // Hint elements live inside a shadow root; Playwright auto-pierces open shadows.
+  // WHY: hint elements live inside a shadow root; Playwright auto-pierces open shadows.
   await expect(page.locator(".hint").first()).toBeVisible({ timeout: 5_000 });
 }
 

--- a/test/e2e/hint-action.spec.ts
+++ b/test/e2e/hint-action.spec.ts
@@ -9,7 +9,6 @@ test.describe("hint actions", () => {
     await gotoTest(page, "input.html");
     await hit(page, "input[type=text]");
 
-    // After Space release the input should be focused.
     await expect(page.locator("input[type=text]").first()).toBeFocused({
       timeout: 3_000,
     });
@@ -55,7 +54,7 @@ test.describe("hint actions", () => {
       .getAttribute("data-hint");
     if (!firstHintText) throw new Error("No hint found");
 
-    // Type the first character — matching hints become candidate/hit.
+    // WHY: typing the first character narrows matching hints to candidate/hit state.
     await page.keyboard.press(firstHintText[0]);
 
     const candidateOrHit = page.locator(

--- a/test/e2e/hint-placement.spec.ts
+++ b/test/e2e/hint-placement.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, gotoTest, attachHints, findHintFor } from "./fixtures";
 
 test.describe("hint placement", () => {
   test.afterEach(async ({ page }) => {
-    // Release Space in case a test did not do so.
+    // WHY: release Space in case a test did not do so.
     await page.keyboard.up("Space").catch(() => void 0);
   });
 
@@ -59,7 +59,7 @@ test.describe("hint placement", () => {
 
     const hints = page.locator(".hint");
     const count = await hints.count();
-    // 4 <area> elements (default, rect, circle, poly)
+    // WHY: 4 <area> elements (default, rect, circle, poly)
     expect(count).toBeGreaterThanOrEqual(4);
 
     await page.keyboard.up("Space");

--- a/test/e2e/iframe-blur-cycle.spec.ts
+++ b/test/e2e/iframe-blur-cycle.spec.ts
@@ -36,7 +36,6 @@ test.describe("iframe blur cycle (sticky mode)", () => {
   }) => {
     await gotoTest(page, "iframe.html");
 
-    // 1. Focus the iframe element via sticky hint
     await attachHintsSticky(page, STICKY_KEY);
     const hintText = await findHintFor(page, "iframe");
     for (const ch of hintText) {
@@ -44,10 +43,9 @@ test.describe("iframe blur cycle (sticky mode)", () => {
     }
     await page.keyboard.press(ACTION_KEY);
 
-    // 2. Blur via blur key
     await page.keyboard.press(BLUR_KEY);
 
-    // 3. Re-focus via sticky hint — the hint key must fire the action, not RemoveHints.
+    // WHY: re-focus via sticky hint; the hint key must fire the action, not RemoveHints.
     await attachHintsSticky(page, STICKY_KEY);
     const hintText2 = await findHintFor(page, "iframe");
     expect(hintText2).toBeTruthy();
@@ -55,7 +53,7 @@ test.describe("iframe blur cycle (sticky mode)", () => {
     for (const ch of hintText2) {
       await page.keyboard.press(ch);
     }
-    // Hints should have been consumed (hit state reached), not cancelled.
+    // INVARIANT: hints should have been consumed (hit state reached), not cancelled.
     const hitHint = page.locator(".hint[data-state='hit']");
     await expect(hitHint).toHaveCount(1, { timeout: 2_000 });
 

--- a/test/e2e/sticky-mode.spec.ts
+++ b/test/e2e/sticky-mode.spec.ts
@@ -7,7 +7,7 @@ import {
   setSettings,
 } from "./fixtures";
 
-// Use keys unlikely to conflict with the default magicKey (Space).
+// WHY: use keys unlikely to conflict with the default magicKey (Space).
 const STICKY_KEY = "KeyQ";
 const ACTION_KEY = "Enter";
 const CANCEL_KEY = "Escape";
@@ -23,7 +23,7 @@ test.describe("sticky mode", () => {
   });
 
   test.afterEach(async ({ context }) => {
-    // Reset to defaults so other tests are not affected.
+    // WHY: reset to defaults so other tests are not affected.
     await setSettings(context, { stickyKey: "", actionKey: "", cancelKey: "" });
   });
 
@@ -31,7 +31,6 @@ test.describe("sticky mode", () => {
     page,
   }) => {
     await attachHintsSticky(page, STICKY_KEY);
-    // After pressing + releasing the sticky key, hints must still be visible.
     await expect(page.locator(".hint").first()).toBeVisible({ timeout: 3_000 });
   });
 
@@ -64,16 +63,13 @@ test.describe("sticky mode", () => {
     await expect(page.locator(".hint").first()).not.toBeVisible({
       timeout: 3_000,
     });
-    // Checkbox must not have toggled.
     expect(await checkbox.isChecked()).toBe(checkedBefore);
   });
 
   test("second sticky session works after an action steals focus", async ({
     page,
   }) => {
-    // First session: fire the action with the Action Key DOWN only and never
-    // send its keyup, simulating a target=_blank action that opens a new tab
-    // and steals focus before keyup arrives. The window then loses focus.
+    // WHY: fire the action with the Action Key DOWN only and never send its keyup, simulating a target=_blank action that steals focus before keyup arrives.
     await attachHintsSticky(page, STICKY_KEY);
     const hintText1 = await findHintFor(page, "input[type=checkbox]");
     for (const ch of hintText1) {
@@ -84,8 +80,7 @@ test.describe("sticky mode", () => {
       timeout: 3_000,
     });
 
-    // Second session: hints must appear and stay visible after one hint letter,
-    // i.e. the stuck Action Key must not spuriously fire removeHints.
+    // INVARIANT: hints must appear and stay visible after one hint letter; the stuck Action Key must not spuriously fire removeHints.
     await attachHintsSticky(page, STICKY_KEY);
     const hintText2 = await findHintFor(page, "input[type=text]");
     await page.keyboard.press(hintText2[0]);

--- a/test/lib/glob-trie.test.ts
+++ b/test/lib/glob-trie.test.ts
@@ -1,7 +1,4 @@
-// Ported from the original `glob-trie.js` test suite
-// (https://github.com/rbranson/glob-trie.js/blob/master/test.js).
-// The `remove` / `nodeCount` based assertions are omitted because those
-// methods are not part of the API used by knavi.
+// WHY: ported from the original glob-trie.js test suite (https://github.com/rbranson/glob-trie.js/blob/master/test.js); `remove` / `nodeCount` based assertions are omitted because those methods are not part of the API used by knavi.
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
@@ -184,7 +181,7 @@ void describe("GlobTrie", () => {
           "*[0-9]",
           "*[0-9]*",
           "*[0-9]*",
-          "*[0-9]*", // matched once per character, as in the original
+          "*[0-9]*", // WHY: matched once per character, as in the original
         ]),
       );
     });
@@ -210,7 +207,6 @@ void describe("GlobTrie", () => {
       );
     });
 
-    // Every escaped metacharacter
     for (const c of ["[", "]", "(", ")", ".", "?", "\\"]) {
       void test(`escaped ${c}`, () => {
         assert.deepStrictEqual(

--- a/test/lib/key-chars.test.ts
+++ b/test/lib/key-chars.test.ts
@@ -14,11 +14,11 @@ void describe("keyCodeToChars", () => {
   });
 
   void test("maps punctuation codes across US and JIS layouts", () => {
-    // Semicolon only differs on US (";").
+    // WHY: Semicolon only differs on US (";").
     assert.deepStrictEqual(keyCodeToChars("Semicolon"), [";"]);
-    // Quote yields "'" on US and ":" on JIS.
+    // WHY: Quote yields "'" on US and ":" on JIS.
     assert.deepStrictEqual(keyCodeToChars("Quote"), ["'", ":"]);
-    // BracketLeft yields "[" on US and "@" on JIS.
+    // WHY: BracketLeft yields "[" on US and "@" on JIS.
     assert.deepStrictEqual(keyCodeToChars("BracketLeft"), ["[", "@"]);
   });
 


### PR DESCRIPTION
## Summary
- Fix all `require-comment-rationale` (ast-grep) violations under `test/`, `scripts/`, `playwright.config.ts`, `eslint.config.ts`, and `docs/`.
- Comments that merely restated the following code were deleted; comments carrying genuine non-obvious context (external gotchas, regression rationale, invariants) were kept and prefixed with `WHY:` / `HACK:` / `INVARIANT:`.
- No logic changes; comment-only edits.

## Test plan
- [x] `npx ast-grep scan test scripts playwright.config.ts eslint.config.ts docs` reports 0 violations
- [x] `npm run lint` passes
- [x] `npm run test` passes (93/93)