### PR TITLE
feat(hinter): add Cycle Key for overlapping hint chips (#112)

### DIFF
--- a/changelog/4.2.0.md
+++ b/changelog/4.2.0.md
@@ -1,0 +1,15 @@
+# Version 4.2.0
+
+Add Cycle Key to reach hint chips buried under overlapping chips.
+
+- Add Cycle Key (default `Tab`) to cycle the hit through hint chips that
+  overlap the currently-hit chip.
+  - When a full label match produces a hit and other chips intersect the hit
+    chip's rect, pressing the Cycle Key moves the hit through those
+    overlapping targets in DOM insertion order.
+  - The cycle set is snapshotted on the first press and stays fixed until any
+    letter is typed, the session is cancelled, or the action fires.
+  - When the hit chip has intersecting chips, a small badge (`Tab +N`)
+    appears on it via a new `data-cycle-key` / `data-cycle-count` pair
+    rendered by the user-overridable CSS through `.hint::before`.
+  - Configure the key in the option page; press "Unbind" to disable.

--- a/changelog/4.2.0.md
+++ b/changelog/4.2.0.md
@@ -12,4 +12,8 @@ Add Cycle Key to reach hint chips buried under overlapping chips.
   - When the hit chip has intersecting chips, a small badge (`Tab +N`)
     appears on it via a new `data-cycle-key` / `data-cycle-count` pair
     rendered by the user-overridable CSS through `.hint::before`.
+  - The badge rules are prepended automatically to your existing custom
+    style on upgrade so the badge shows without any manual edit. You can
+    remove them in the option page if you prefer, or press "Restore Default
+    Style" to reset.
   - Configure the key in the option page; press "Unbind" to disable.

--- a/docs/tests/overlapping-hints.html
+++ b/docs/tests/overlapping-hints.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Overlapping hints</title>
+    <style>
+      body {
+        margin: 40px;
+        font-family: sans-serif;
+      }
+      #stack {
+        position: relative;
+        width: 300px;
+        height: 120px;
+      }
+      #back,
+      #front {
+        position: absolute;
+        left: 0;
+        top: 0;
+      }
+      #back {
+        width: 300px;
+        height: 120px;
+        border: 1px solid #ccc;
+        background: #f0f0f0;
+      }
+      #front {
+        padding: 4px 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      Two clickable elements share the top-left anchor: a large card and a small
+      link on top of it.
+    </p>
+    <div id="stack">
+      <button
+        id="back"
+        type="button"
+        onclick="document.body.setAttribute('data-back-clicked', '1')"
+      >
+        outer card
+      </button>
+      <a
+        id="front"
+        href="javascript:void(document.body.setAttribute('data-front-clicked','1'))"
+        >front link</a
+      >
+    </div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "knavi",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A Hit-a-Hint Chrome extension. Press the space key plus a hint key to click links and buttons without a mouse.",
   "type": "module",
   "scripts": {

--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -22,6 +22,11 @@ export const router = Router.newRuntimeInstance()
       },
     );
   })
+  .add("CycleHint", async (_msg, sender) => {
+    return await sendToTab(requireTabId(sender), "CycleHintInTab", undefined, {
+      frameId: 0,
+    });
+  })
   .add("RemoveHints", async ({ options, execute }, sender) => {
     return await sendToTab(
       requireTabId(sender),

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -5,7 +5,7 @@ const BACKDROP_RULE =
   ":host::backdrop { background-color: transparent !important; }";
 
 const CYCLE_BADGE_RULES = `.hint::before {
-  content: "⟳ " attr(data-cycle-key) " (+" attr(data-cycle-count) ")";
+  content: "⟳ " attr(data-cycle-key) " " attr(data-cycle-index) "/" attr(data-cycle-total);
   text-transform: none;
   font-size: 50%;
   position: absolute;

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -5,7 +5,7 @@ const BACKDROP_RULE =
   ":host::backdrop { background-color: transparent !important; }";
 
 const CYCLE_BADGE_RULES = `.hint::before {
-  content: attr(data-cycle-key) " +" attr(data-cycle-count);
+  content: "⟳ " attr(data-cycle-key) " (+" attr(data-cycle-count) ")";
   text-transform: none;
   font-size: 50%;
   position: absolute;

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -4,6 +4,26 @@ import { printError } from "../lib/errors";
 const BACKDROP_RULE =
   ":host::backdrop { background-color: transparent !important; }";
 
+const CYCLE_BADGE_RULES = `.hint::before {
+  content: attr(data-cycle-key) " +" attr(data-cycle-count);
+  text-transform: none;
+  font-size: 50%;
+  position: absolute;
+  background-color: #333;
+  color: white;
+  border: #ccc 1px solid;
+  padding: 3px;
+  border-radius: 4px;
+  line-height: 1em;
+  left: 0;
+  bottom: calc(100% + 2px);
+  display: none;
+  white-space: nowrap;
+}
+.hint[data-state="hit"][data-cycle-key]::before {
+  display: inline-block;
+}`;
+
 export interface StorageHandle {
   getSingle(key: "css"): Promise<string | null | undefined>;
   setSingle(key: "css", value: string): Promise<void>;
@@ -24,6 +44,11 @@ export function isOlderThan400(version: string): boolean {
   return major < 4;
 }
 
+export function isOlderThan420(version: string): boolean {
+  const [major, minor] = version.split(".").map(Number);
+  return major < 4 || (major === 4 && minor < 2);
+}
+
 export async function migrate400(storage: StorageHandle) {
   const css = await storage.getSingle("css");
   if (css == null || css.includes(":host::backdrop")) return;
@@ -31,6 +56,18 @@ export async function migrate400(storage: StorageHandle) {
     "/* Added automatically on migration to v4.0.0. You can remove this if not needed. */";
   await storage.setSingle("css", comment + "\n" + BACKDROP_RULE + "\n\n" + css);
   console.info("[knavi] migration 4.0.0: prepended backdrop rule to css");
+}
+
+export async function migrate420(storage: StorageHandle) {
+  const css = await storage.getSingle("css");
+  if (css == null || css.includes("data-cycle-key")) return;
+  const comment =
+    "/* Added automatically on migration to v4.2.0. You can remove this if not needed. */";
+  await storage.setSingle(
+    "css",
+    comment + "\n" + CYCLE_BADGE_RULES + "\n\n" + css,
+  );
+  console.info("[knavi] migration 4.2.0: prepended cycle-badge rules to css");
 }
 
 /**
@@ -60,9 +97,10 @@ async function handleUpdate(
   previousVersion?: string,
 ) {
   await settings.backfillDefaults();
-  if (previousVersion && isOlderThan400(previousVersion)) {
-    await migrate400(await settings.getStorage());
-  }
+  if (!previousVersion) return;
+  const storage = await settings.getStorage();
+  if (isOlderThan400(previousVersion)) await migrate400(storage);
+  if (isOlderThan420(previousVersion)) await migrate420(storage);
 }
 
 export function init(settings: typeof Settings) {

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -15,13 +15,14 @@ const CYCLE_BADGE_RULES = `.hint::before {
   padding: 3px;
   border-radius: 4px;
   line-height: 1em;
-  left: 0;
-  bottom: calc(100% + 2px);
-  display: none;
-  white-space: nowrap;
+  transition: 200ms;
+  bottom: 0px;
+  opacity: 0;
 }
 .hint[data-state="hit"][data-cycle-key]::before {
-  display: inline-block;
+  transition-delay: 200ms;
+  bottom: calc(100% + 4px);
+  opacity: 1;
 }`;
 
 export interface StorageHandle {

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -30,6 +30,7 @@ async function setupKeyboardHandler() {
       "stickyKey",
       "actionKey",
       "cancelKey",
+      "cycleKey",
     ]),
     settingsClient.matchBlacklist(location.href),
   ]);
@@ -46,6 +47,7 @@ const RELEVANT_KEYS: (keyof Settings)[] = [
   "stickyKey",
   "actionKey",
   "cancelKey",
+  "cycleKey",
   "blackList",
 ];
 

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -11,6 +11,7 @@ export class KeyboardHandlerContentAll {
   private stickyMatcher: KeyHoldMatcher | null = null;
   private actionMatcher: KeyHoldMatcher | null = null;
   private cancelMatcher: KeyHoldMatcher | null = null;
+  private cycleMatcher: KeyHoldMatcher | null = null;
   private hintLetters = "";
   private matchedBlacklist: string[] = [];
   /**
@@ -27,7 +28,13 @@ export class KeyboardHandlerContentAll {
   setup(
     settings: Pick<
       Settings,
-      "magicKey" | "blurKey" | "hints" | "stickyKey" | "actionKey" | "cancelKey"
+      | "magicKey"
+      | "blurKey"
+      | "hints"
+      | "stickyKey"
+      | "actionKey"
+      | "cancelKey"
+      | "cycleKey"
     >,
     matchedBlacklist: string[],
   ) {
@@ -48,6 +55,8 @@ export class KeyboardHandlerContentAll {
       settings.cancelKey === ""
         ? null
         : KeyHoldMatcher.parse(settings.cancelKey);
+    this.cycleMatcher =
+      settings.cycleKey === "" ? null : KeyHoldMatcher.parse(settings.cycleKey);
     this.matchedBlacklist = matchedBlacklist;
   }
 
@@ -61,6 +70,7 @@ export class KeyboardHandlerContentAll {
     this.stickyMatcher?.reset();
     this.actionMatcher?.reset();
     this.cancelMatcher?.reset();
+    this.cycleMatcher?.reset();
   }
 
   /** Returns true if the event is handled. */
@@ -70,6 +80,7 @@ export class KeyboardHandlerContentAll {
     const stickyMatcher = this.stickyMatcher?.keydown(event);
     const actionMatcher = this.actionMatcher?.keydown(event);
     const cancelMatcher = this.cancelMatcher?.keydown(event);
+    const cycleMatcher = this.cycleMatcher?.keydown(event);
 
     if (this.isBlacklisted()) {
       return false;
@@ -90,6 +101,10 @@ export class KeyboardHandlerContentAll {
           .removeHints({ shiftKey, altKey, ctrlKey, metaKey }, true)
           .catch(printError);
         this.endSession();
+        return true;
+      }
+      if (cycleMatcher?.match()) {
+        this.hinter.cycleHint().catch(printError);
         return true;
       }
       if (isSingleLetter(event.key) && this.hintLetters.includes(event.key)) {
@@ -124,6 +139,7 @@ export class KeyboardHandlerContentAll {
     this.stickyMatcher?.keyup(event);
     this.actionMatcher?.keyup(event);
     this.cancelMatcher?.keyup(event);
+    this.cycleMatcher?.keyup(event);
 
     if (this.isBlacklisted()) {
       return false;

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -22,7 +22,8 @@ const blurer = new BlurerContentRoot(blurerView);
     "hints",
     "cycleKey",
   ]);
-  hinterView.setup(css, cycleKey);
+  hinterView.setCss(css);
+  hinterView.setCycleKey(cycleKey);
   hinter.setup(hints);
 })().catch(printError);
 

--- a/src/content-root.ts
+++ b/src/content-root.ts
@@ -17,14 +17,21 @@ const blurerView = new BlurView();
 const blurer = new BlurerContentRoot(blurerView);
 
 (async () => {
-  const { css, hints } = await settingsClient.get(["css", "hints"]);
-  hinterView.setup(css);
+  const { css, hints, cycleKey } = await settingsClient.get([
+    "css",
+    "hints",
+    "cycleKey",
+  ]);
+  hinterView.setup(css, cycleKey);
   hinter.setup(hints);
 })().catch(printError);
 
 chrome.storage.onChanged.addListener((changes) => {
   if (changes.css) {
-    hinterView.setup(changes.css.newValue as Settings["css"]);
+    hinterView.setCss(changes.css.newValue as Settings["css"]);
+  }
+  if (changes.cycleKey) {
+    hinterView.setCycleKey(changes.cycleKey.newValue as Settings["cycleKey"]);
   }
   if (changes.hints) {
     hinter.setup(changes.hints.newValue as Settings["hints"]);
@@ -38,6 +45,7 @@ chrome.runtime.onMessage.addListener(
     )
     .add("AttachHintsInTab", () => hinter.attachHints())
     .add("HitHintInTab", ({ key }) => hinter.hitHint(key))
+    .add("CycleHintInTab", () => hinter.cycleHint())
     .add("RemoveHintsInTab", ({ options, execute }) =>
       hinter.removeHints(options, execute),
     )

--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -135,14 +135,13 @@ export class HintView {
   hit(
     changes: HintedElement[],
     actionDescriptions: ActionDescriptions | null,
-    cycleBadge: { count: number } | null,
+    cycleBadge: { count: number; index: number } | null,
   ) {
     if (!this.hints) throw Error("Illegal state");
     this.clearCycleBadge();
     this.highlightHints(changes, actionDescriptions);
     const hitTarget = changes.find((t) => t.state === "hit") ?? null;
-    if (hitTarget && cycleBadge)
-      this.setCycleBadge(hitTarget, cycleBadge.count);
+    if (hitTarget && cycleBadge) this.setCycleBadge(hitTarget, cycleBadge);
     this.moveOverlay();
     this.moveActiveOverlay(hitTarget);
   }
@@ -166,12 +165,16 @@ export class HintView {
     return result;
   }
 
-  private setCycleBadge(hit: HintedElement, count: number) {
+  private setCycleBadge(
+    hit: HintedElement,
+    badge: { count: number; index: number },
+  ) {
     const entry = this.hints!.get(hit);
     if (!entry) return;
     for (const el of entry.hints) {
       el.dataset.cycleKey = this.cycleKey;
-      el.dataset.cycleCount = String(count);
+      el.dataset.cycleCount = String(badge.count);
+      el.dataset.cycleIndex = String(badge.index);
     }
   }
 
@@ -180,6 +183,7 @@ export class HintView {
       for (const el of hints) {
         delete el.dataset.cycleKey;
         delete el.dataset.cycleCount;
+        delete el.dataset.cycleIndex;
       }
     }
   }

--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -20,6 +20,7 @@ export class HintView {
 
   private style: HTMLStyleElement;
   private hints: Hints | null = null;
+  private cycleKey = "";
 
   constructor() {
     this.container = document.createElement("div");
@@ -38,8 +39,17 @@ export class HintView {
     this.style = this.root.appendChild(document.createElement("style"));
   }
 
-  setup(css: string) {
+  setup(css: string, cycleKey: string) {
     this.style.textContent = css;
+    this.cycleKey = cycleKey;
+  }
+
+  setCss(css: string) {
+    this.style.textContent = css;
+  }
+
+  setCycleKey(cycleKey: string) {
+    this.cycleKey = cycleKey;
   }
 
   isStarted(): boolean {
@@ -127,11 +137,56 @@ export class HintView {
     });
   }
 
-  hit(changes: HintedElement[], actionDescriptions: ActionDescriptions | null) {
+  hit(
+    changes: HintedElement[],
+    actionDescriptions: ActionDescriptions | null,
+    cycleBadge: { count: number } | null,
+  ) {
     if (!this.hints) throw Error("Illegal state");
+    this.clearCycleBadge();
     this.highlightHints(changes, actionDescriptions);
+    const hitTarget = changes.find((t) => t.state === "hit") ?? null;
+    if (hitTarget && cycleBadge)
+      this.setCycleBadge(hitTarget, cycleBadge.count);
     this.moveOverlay();
-    this.moveActiveOverlay(changes.find((t) => t.state === "hit") ?? null);
+    this.moveActiveOverlay(hitTarget);
+  }
+
+  /**
+   * Returns targets whose first hint chip's viewport rect intersects the given
+   * hit's first chip rect with positive area. Includes the hit itself.
+   * Iteration order matches DOM insertion order.
+   */
+  computeCycleSet(hit: HintedElement): HintedElement[] {
+    if (!this.hints) return [];
+    const hitEntry = this.hints.get(hit);
+    if (!hitEntry || hitEntry.hints.length === 0) return [];
+    const hitRect = hitEntry.hints[0].getBoundingClientRect();
+    const result: HintedElement[] = [];
+    for (const { hinted, hints } of this.hints.all()) {
+      if (hints.length === 0) continue;
+      const r = hints[0].getBoundingClientRect();
+      if (intersectsWithPositiveArea(hitRect, r)) result.push(hinted);
+    }
+    return result;
+  }
+
+  private setCycleBadge(hit: HintedElement, count: number) {
+    const entry = this.hints!.get(hit);
+    if (!entry) return;
+    for (const el of entry.hints) {
+      el.dataset.cycleKey = this.cycleKey;
+      el.dataset.cycleCount = String(count);
+    }
+  }
+
+  private clearCycleBadge() {
+    for (const { hints } of this.hints!.all()) {
+      for (const el of hints) {
+        delete el.dataset.cycleKey;
+        delete el.dataset.cycleCount;
+      }
+    }
   }
 
   private highlightHints(
@@ -270,4 +325,12 @@ function buildHintElements(target: HintedElement): HTMLElement[] {
 
 function px(n: number): string {
   return `${Math.round(n)}px`;
+}
+
+function intersectsWithPositiveArea(a: DOMRect, b: DOMRect): boolean {
+  const left = Math.max(a.left, b.left);
+  const right = Math.min(a.right, b.right);
+  const top = Math.max(a.top, b.top);
+  const bottom = Math.min(a.bottom, b.bottom);
+  return right > left && bottom > top;
 }

--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -39,11 +39,6 @@ export class HintView {
     this.style = this.root.appendChild(document.createElement("style"));
   }
 
-  setup(css: string, cycleKey: string) {
-    this.style.textContent = css;
-    this.cycleKey = cycleKey;
-  }
-
   setCss(css: string) {
     this.style.textContent = css;
   }

--- a/src/content-root/hinter-view.ts
+++ b/src/content-root/hinter-view.ts
@@ -135,7 +135,7 @@ export class HintView {
   hit(
     changes: HintedElement[],
     actionDescriptions: ActionDescriptions | null,
-    cycleBadge: { count: number; index: number } | null,
+    cycleBadge: { count: number; index: number; total: number } | null,
   ) {
     if (!this.hints) throw Error("Illegal state");
     this.clearCycleBadge();
@@ -167,7 +167,7 @@ export class HintView {
 
   private setCycleBadge(
     hit: HintedElement,
-    badge: { count: number; index: number },
+    badge: { count: number; index: number; total: number },
   ) {
     const entry = this.hints!.get(hit);
     if (!entry) return;
@@ -175,6 +175,7 @@ export class HintView {
       el.dataset.cycleKey = this.cycleKey;
       el.dataset.cycleCount = String(badge.count);
       el.dataset.cycleIndex = String(badge.index);
+      el.dataset.cycleTotal = String(badge.total);
     }
   }
 
@@ -184,6 +185,7 @@ export class HintView {
         delete el.dataset.cycleKey;
         delete el.dataset.cycleCount;
         delete el.dataset.cycleIndex;
+        delete el.dataset.cycleTotal;
       }
     }
   }

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -8,6 +8,12 @@ interface HintContext {
   targets: HintedElement[];
   inputSequence: string[];
   hitTarget?: HintedElement | undefined;
+  /**
+   * Snapshot taken on the first Cycle Key press. Fixed set of targets whose
+   * chip rects intersected the originally-hit chip. Repeated presses cycle
+   * through it in DOM insertion order; any letter input clears it.
+   */
+  cycle?: { set: HintedElement[]; index: number } | undefined;
 }
 
 export class HinterContentRoot {
@@ -101,12 +107,51 @@ export class HinterContentRoot {
 
     if (!this.hintLetters.includes(inputLetter)) return;
 
+    delete context.cycle;
+
     const changes = [...updateContext(context, inputLetter)];
 
     const actionDescriptions = context.hitTarget
       ? context.hitTarget.descriptions
       : null;
-    this.view.hit(changes, actionDescriptions);
+    const cycleBadge = this.computeCycleBadge(context);
+    this.view.hit(changes, actionDescriptions, cycleBadge);
+  }
+
+  cycleHint() {
+    const context = this.context;
+    if (!context) throw Error("Ilegal state invocation: hinting not started");
+    if (!context.hitTarget) return;
+
+    if (!context.cycle) {
+      const set = this.view.computeCycleSet(context.hitTarget);
+      if (set.length <= 1) return;
+      const index = set.indexOf(context.hitTarget);
+      if (index < 0) return;
+      context.cycle = { set, index };
+    }
+
+    const cycle = context.cycle;
+    const prevHit = context.hitTarget;
+    cycle.index = (cycle.index + 1) % cycle.set.length;
+    const newHit = cycle.set[cycle.index];
+    if (newHit === prevHit) return;
+
+    prevHit.state = "candidate";
+    newHit.state = "hit";
+    context.hitTarget = newHit;
+
+    this.view.hit([prevHit, newHit], newHit.descriptions, {
+      count: cycle.set.length - 1,
+    });
+  }
+
+  private computeCycleBadge(context: HintContext): { count: number } | null {
+    if (!context.hitTarget) return null;
+    if (context.cycle) return { count: context.cycle.set.length - 1 };
+    const set = this.view.computeCycleSet(context.hitTarget);
+    const count = set.length - 1;
+    return count > 0 ? { count } : null;
   }
 
   async removeHints(options: ActionOptions, execute: boolean) {

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -111,10 +111,10 @@ export class HinterContentRoot {
 
     const changes = [...updateContext(context, inputLetter)];
 
-    const actionDescriptions = context.hitTarget
-      ? context.hitTarget.descriptions
+    const actionDescriptions = context.hitTarget?.descriptions ?? null;
+    const cycleBadge = context.hitTarget
+      ? cycleBadgeFor(this.view.computeCycleSet(context.hitTarget))
       : null;
-    const cycleBadge = this.computeCycleBadge(context);
     this.view.hit(changes, actionDescriptions, cycleBadge);
   }
 
@@ -144,14 +144,6 @@ export class HinterContentRoot {
     this.view.hit([prevHit, newHit], newHit.descriptions, {
       count: cycle.set.length - 1,
     });
-  }
-
-  private computeCycleBadge(context: HintContext): { count: number } | null {
-    if (!context.hitTarget) return null;
-    if (context.cycle) return { count: context.cycle.set.length - 1 };
-    const set = this.view.computeCycleSet(context.hitTarget);
-    const count = set.length - 1;
-    return count > 0 ? { count } : null;
   }
 
   async removeHints(options: ActionOptions, execute: boolean) {
@@ -200,6 +192,11 @@ function* updateContext(
       yield t;
     }
   }
+}
+
+function cycleBadgeFor(set: HintedElement[]): { count: number } | null {
+  const count = set.length - 1;
+  return count > 0 ? { count } : null;
 }
 
 function take<T>(iter: Generator<T>, length: number): T[] {

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -113,7 +113,10 @@ export class HinterContentRoot {
 
     const actionDescriptions = context.hitTarget?.descriptions ?? null;
     const cycleBadge = context.hitTarget
-      ? cycleBadgeFor(this.view.computeCycleSet(context.hitTarget))
+      ? cycleBadgeFor(
+          this.view.computeCycleSet(context.hitTarget),
+          context.hitTarget,
+        )
       : null;
     this.view.hit(changes, actionDescriptions, cycleBadge);
   }
@@ -143,6 +146,7 @@ export class HinterContentRoot {
 
     this.view.hit([prevHit, newHit], newHit.descriptions, {
       count: cycle.set.length - 1,
+      index: cycle.index + 1,
     });
   }
 
@@ -194,9 +198,14 @@ function* updateContext(
   }
 }
 
-function cycleBadgeFor(set: HintedElement[]): { count: number } | null {
+function cycleBadgeFor(
+  set: HintedElement[],
+  hit: HintedElement,
+): { count: number; index: number } | null {
   const count = set.length - 1;
-  return count > 0 ? { count } : null;
+  if (count <= 0) return null;
+  const index = set.indexOf(hit) + 1;
+  return { count, index };
 }
 
 function take<T>(iter: Generator<T>, length: number): T[] {

--- a/src/content-root/hinter.ts
+++ b/src/content-root/hinter.ts
@@ -147,6 +147,7 @@ export class HinterContentRoot {
     this.view.hit([prevHit, newHit], newHit.descriptions, {
       count: cycle.set.length - 1,
       index: cycle.index + 1,
+      total: cycle.set.length,
     });
   }
 
@@ -201,11 +202,11 @@ function* updateContext(
 function cycleBadgeFor(
   set: HintedElement[],
   hit: HintedElement,
-): { count: number; index: number } | null {
+): { count: number; index: number; total: number } | null {
   const count = set.length - 1;
   if (count <= 0) return null;
   const index = set.indexOf(hit) + 1;
-  return { count, index };
+  return { count, index, total: set.length };
 }
 
 function take<T>(iter: Generator<T>, length: number): T[] {

--- a/src/default-style.css
+++ b/src/default-style.css
@@ -133,7 +133,8 @@
 }
 
 .hint::before {
-  content: "⟳ " attr(data-cycle-key) " (+" attr(data-cycle-count) ")";
+  content: "⟳ " attr(data-cycle-key) " " attr(data-cycle-index) "/"
+    attr(data-cycle-total);
   bottom: 0px;
 }
 .hint[data-state="hit"][data-cycle-key]::before {

--- a/src/default-style.css
+++ b/src/default-style.css
@@ -139,8 +139,8 @@
   padding: 3px;
   border-radius: 4px;
   line-height: 1em;
-  right: calc(100% + 4px);
-  top: 0;
+  left: 0;
+  bottom: calc(100% + 2px);
   display: none;
   white-space: nowrap;
 }

--- a/src/default-style.css
+++ b/src/default-style.css
@@ -127,3 +127,23 @@
   left: calc(100% + 4px);
   opacity: 1;
 }
+
+.hint::before {
+  content: attr(data-cycle-key) " +" attr(data-cycle-count);
+  text-transform: none;
+  font-size: 50%;
+  position: absolute;
+  background-color: #333;
+  color: white;
+  border: #ccc 1px solid;
+  padding: 3px;
+  border-radius: 4px;
+  line-height: 1em;
+  right: calc(100% + 4px);
+  top: 0;
+  display: none;
+  white-space: nowrap;
+}
+.hint[data-state="hit"][data-cycle-key]::before {
+  display: inline-block;
+}

--- a/src/default-style.css
+++ b/src/default-style.css
@@ -107,9 +107,9 @@
   z-index: 2;
 }
 
-.hint:after {
+.hint:after,
+.hint:before {
   text-transform: none;
-  content: attr(data-action-description);
   font-size: 50%;
   position: absolute;
   background-color: #333;
@@ -119,8 +119,12 @@
   border-radius: 4px;
   line-height: 1em;
   transition: 200ms;
-  left: 0px;
   opacity: 0;
+}
+
+.hint:after {
+  content: attr(data-action-description);
+  left: 0px;
 }
 .hint[data-state="hit"]:after {
   transition-delay: 100ms;
@@ -130,20 +134,10 @@
 
 .hint::before {
   content: attr(data-cycle-key) " +" attr(data-cycle-count);
-  text-transform: none;
-  font-size: 50%;
-  position: absolute;
-  background-color: #333;
-  color: white;
-  border: #ccc 1px solid;
-  padding: 3px;
-  border-radius: 4px;
-  line-height: 1em;
-  left: 0;
-  bottom: calc(100% + 2px);
-  display: none;
-  white-space: nowrap;
+  bottom: 0px;
 }
 .hint[data-state="hit"][data-cycle-key]::before {
-  display: inline-block;
+  transition-delay: 200ms;
+  bottom: calc(100% + 4px);
+  opacity: 1;
 }

--- a/src/default-style.css
+++ b/src/default-style.css
@@ -133,7 +133,7 @@
 }
 
 .hint::before {
-  content: attr(data-cycle-key) " +" attr(data-cycle-count);
+  content: "⟳ " attr(data-cycle-key) " (+" attr(data-cycle-count) ")";
   bottom: 0px;
 }
 .hint[data-state="hit"][data-cycle-key]::before {

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -26,6 +26,10 @@ export interface RuntimeMessages {
     payload: { key: SingleLetter };
     response: void;
   };
+  CycleHint: {
+    payload: void;
+    response: void;
+  };
   RemoveHints: {
     payload: { options: ActionOptions; execute: boolean };
     response: void;
@@ -71,6 +75,10 @@ export interface TabMessages {
   };
   HitHintInTab: {
     payload: { key: SingleLetter };
+    response: void;
+  };
+  CycleHintInTab: {
+    payload: void;
     response: void;
   };
   RemoveHintsInTab: {

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -51,6 +51,11 @@ export default class HinterClient {
     await sendToRuntime("HitHint", { key });
   }
 
+  async cycleHint() {
+    if (!this.hinting) throw Error("Illegal state");
+    await sendToRuntime("CycleHint", undefined);
+  }
+
   async removeHints(options: ActionOptions, execute: boolean) {
     if (!this.hinting) throw Error("Illegal state");
     this.hinting = false;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -24,6 +24,7 @@ const DEFAULT_SETTINGS: Settings = {
   stickyKey: "",
   actionKey: "",
   cancelKey: "",
+  cycleKey: "Tab",
   css: "", // WHY: loaded lazily from an external file (default-style.css).
   blackList: DEFAULT_BLACK_LIST,
   additionalSelectors: DEFAULT_ADDITIONAL_SELECTORS,

--- a/src/options.html
+++ b/src/options.html
@@ -166,6 +166,41 @@
         </tr>
       </table>
 
+      <h2>Cycle Key</h2>
+      <p>
+        When the selected hint chip is overlapped by other chips, press the
+        Cycle Key to move the selection through those overlapping hints without
+        typing more letters. Press [Unbind] to disable.
+      </p>
+      <table class="config-table">
+        <tr>
+          <th><label for="cycle-key">Cycle Key</label></th>
+          <td>
+            <input
+              is="key-input"
+              id="cycle-key"
+              name="cycleKey"
+              value="Tab"
+              autocomplete="off"
+            />
+            <button
+              data-valueset-target="#cycle-key"
+              data-valueset-default
+              title="Reset to the default key"
+            >
+              Reset
+            </button>
+            <button
+              data-valueset-target="#cycle-key"
+              data-valueset=""
+              title="Unbind to disable"
+            >
+              Unbind
+            </button>
+          </td>
+        </tr>
+      </table>
+
       <h2>Style</h2>
 
       <p>Styles for the hint elements and overlays.</p>

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,6 +28,7 @@ const KEY_LABELS: Record<string, string> = {
   blurKey: "Blur Key",
   actionKey: "Action Key",
   cancelKey: "Cancel Key",
+  cycleKey: "Cycle Key",
   hints: "Hint Letters",
 };
 
@@ -53,7 +54,7 @@ const KEY_PAIR_CONFLICTS: [string, string][] = [
 /* WHY: Key patterns that must not coincide with a hint letter: only keys that fire
    during the hinting phase. (Sticky Key and Blur Key fire only while not
    hinting, so they are excluded.) */
-const HINTS_VS_KEYS = ["magicKey", "actionKey", "cancelKey"];
+const HINTS_VS_KEYS = ["magicKey", "actionKey", "cancelKey", "cycleKey"];
 
 /** Normalize a key-input pattern string (e.g. "Ctrl + KeyA") for comparison. */
 function normalizeKeyPattern(value: string): string {

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -10,6 +10,7 @@ declare interface Settings {
   stickyKey: string;
   actionKey: string;
   cancelKey: string;
+  cycleKey: string;
   css: string;
   blackList: string;
   additionalSelectors: string;

--- a/test/background/migration.test.ts
+++ b/test/background/migration.test.ts
@@ -29,7 +29,7 @@ function makeSettings(css: string | null) {
 }
 
 void describe("onInstalled", () => {
-  void test("backfills and migrates css when upgrading from v3.x", async () => {
+  void test("backfills and applies both migrations when upgrading from v3.x", async () => {
     const { settings, getStored, wasBackfilled } = makeSettings(
       ".hint { color: red; }",
     );
@@ -37,6 +37,7 @@ void describe("onInstalled", () => {
 
     assert.ok(wasBackfilled());
     assert.ok(getStored()!.includes(":host::backdrop"));
+    assert.ok(getStored()!.includes("data-cycle-key"));
   });
 
   void test("backfills on fresh install without migrating", async () => {
@@ -47,9 +48,18 @@ void describe("onInstalled", () => {
     assert.equal(getStored(), ".hint {}");
   });
 
-  void test("backfills but skips migration when updating from v4.x", async () => {
+  void test("backfills and applies 4.2.0 migration when updating from v4.0.0", async () => {
     const { settings, getStored, wasBackfilled } = makeSettings(".hint {}");
     await onInstalled({ reason: "update", previousVersion: "4.0.0" }, settings);
+
+    assert.ok(wasBackfilled());
+    assert.ok(!getStored()!.includes(":host::backdrop"));
+    assert.ok(getStored()!.includes("data-cycle-key"));
+  });
+
+  void test("backfills but skips all migrations when updating from v4.2.0", async () => {
+    const { settings, getStored, wasBackfilled } = makeSettings(".hint {}");
+    await onInstalled({ reason: "update", previousVersion: "4.2.0" }, settings);
 
     assert.ok(wasBackfilled());
     assert.equal(getStored(), ".hint {}");
@@ -61,5 +71,12 @@ void describe("onInstalled", () => {
 
     assert.ok(wasBackfilled());
     assert.equal(getStored(), ".hint {}");
+  });
+
+  void test("4.2.0 migration is idempotent (skips when data-cycle-key already present)", async () => {
+    const original = ".hint::before { content: attr(data-cycle-key); }";
+    const { settings, getStored } = makeSettings(original);
+    await onInstalled({ reason: "update", previousVersion: "4.1.0" }, settings);
+    assert.equal(getStored(), original);
   });
 });

--- a/test/e2e/cycle-hint.spec.ts
+++ b/test/e2e/cycle-hint.spec.ts
@@ -55,28 +55,27 @@ test.describe("cycle key on overlapping hints", () => {
     await expect(hit).toHaveAttribute("data-cycle-key", CYCLE_KEY);
     await expect(hit).toHaveAttribute("data-cycle-count", "1");
 
-    /* WHY: the badge is rendered via the CSS ::before pseudo-element; assert
-       it is visible on-screen (not clipped by the overlay container's
-       overflow:hidden and not display:none). */
-    const badge = await page.evaluate(() => {
-      const root = document.querySelector(
-        "#com-github-kui-knavi-container",
-      )?.shadowRoot;
-      const chip = root?.querySelector<HTMLElement>(".hint[data-state='hit']");
-      if (!chip) return null;
-      const chipRect = chip.getBoundingClientRect();
-      const s = getComputedStyle(chip, "::before");
-      return {
-        content: s.content,
-        display: s.display,
-        visibility: s.visibility,
-        chipRect: { x: chipRect.x, y: chipRect.y },
-        vp: { w: window.innerWidth, h: window.innerHeight },
-      };
-    });
-    expect(badge).not.toBeNull();
-    expect(badge!.display).not.toBe("none");
-    expect(badge!.visibility).not.toBe("hidden");
+    /* WHY: the badge is rendered via the CSS ::before pseudo-element; the
+       hit state fades it in via opacity transition (delay 200ms + 200ms
+       duration). Poll until opacity settles to catch cases where the rule
+       is missing or gated off. */
+    const readBadge = () =>
+      page.evaluate(() => {
+        const root = document.querySelector(
+          "#com-github-kui-knavi-container",
+        )?.shadowRoot;
+        const chip = root?.querySelector<HTMLElement>(
+          ".hint[data-state='hit']",
+        );
+        if (!chip) return null;
+        const s = getComputedStyle(chip, "::before");
+        return {
+          content: s.content,
+          opacity: s.opacity,
+        };
+      });
+    await expect.poll(async () => (await readBadge())?.opacity).toBe("1");
+    const badge = await readBadge();
     expect(badge!.content).toContain(CYCLE_KEY);
     expect(badge!.content).toContain("+1");
 

--- a/test/e2e/cycle-hint.spec.ts
+++ b/test/e2e/cycle-hint.spec.ts
@@ -55,6 +55,31 @@ test.describe("cycle key on overlapping hints", () => {
     await expect(hit).toHaveAttribute("data-cycle-key", CYCLE_KEY);
     await expect(hit).toHaveAttribute("data-cycle-count", "1");
 
+    /* WHY: the badge is rendered via the CSS ::before pseudo-element; assert
+       it is visible on-screen (not clipped by the overlay container's
+       overflow:hidden and not display:none). */
+    const badge = await page.evaluate(() => {
+      const root = document.querySelector(
+        "#com-github-kui-knavi-container",
+      )?.shadowRoot;
+      const chip = root?.querySelector<HTMLElement>(".hint[data-state='hit']");
+      if (!chip) return null;
+      const chipRect = chip.getBoundingClientRect();
+      const s = getComputedStyle(chip, "::before");
+      return {
+        content: s.content,
+        display: s.display,
+        visibility: s.visibility,
+        chipRect: { x: chipRect.x, y: chipRect.y },
+        vp: { w: window.innerWidth, h: window.innerHeight },
+      };
+    });
+    expect(badge).not.toBeNull();
+    expect(badge!.display).not.toBe("none");
+    expect(badge!.visibility).not.toBe("hidden");
+    expect(badge!.content).toContain(CYCLE_KEY);
+    expect(badge!.content).toContain("+1");
+
     await page.keyboard.press(CYCLE_KEY);
 
     const cycledHit = await page

--- a/test/e2e/cycle-hint.spec.ts
+++ b/test/e2e/cycle-hint.spec.ts
@@ -1,0 +1,80 @@
+import {
+  test,
+  expect,
+  gotoTest,
+  attachHintsSticky,
+  setSettings,
+} from "./fixtures";
+
+const STICKY_KEY = "KeyQ";
+const ACTION_KEY = "Enter";
+const CANCEL_KEY = "Escape";
+const CYCLE_KEY = "Tab";
+
+test.describe("cycle key on overlapping hints", () => {
+  test.beforeEach(async ({ context }) => {
+    await setSettings(context, {
+      stickyKey: STICKY_KEY,
+      actionKey: ACTION_KEY,
+      cancelKey: CANCEL_KEY,
+      cycleKey: CYCLE_KEY,
+    });
+  });
+
+  test.afterEach(async ({ context }) => {
+    await setSettings(context, {
+      stickyKey: "",
+      actionKey: "",
+      cancelKey: "",
+      cycleKey: "Tab",
+    });
+  });
+
+  test("Tab cycles the hit and Action fires the cycled-to target", async ({
+    page,
+  }) => {
+    await gotoTest(page, "overlapping-hints.html");
+    await attachHintsSticky(page, STICKY_KEY);
+
+    const hints = page.locator(".hint");
+    /* WHY: the two chips stack at the same top-left; the later-inserted one
+       paints on top in DOM stacking order, so the user only sees its label. */
+    const topHintText = await hints.last().getAttribute("data-hint");
+    const buriedHintText = await hints.first().getAttribute("data-hint");
+    if (!topHintText || !buriedHintText) throw new Error("hint text missing");
+    expect(topHintText).not.toBe(buriedHintText);
+
+    for (const ch of topHintText) await page.keyboard.press(ch);
+
+    const initialHit = await page
+      .locator(".hint[data-state='hit']")
+      .getAttribute("data-hint");
+    expect(initialHit).toBe(topHintText);
+
+    const hit = page.locator(".hint[data-state='hit']");
+    await expect(hit).toHaveAttribute("data-cycle-key", CYCLE_KEY);
+    await expect(hit).toHaveAttribute("data-cycle-count", "1");
+
+    await page.keyboard.press(CYCLE_KEY);
+
+    const cycledHit = await page
+      .locator(".hint[data-state='hit']")
+      .getAttribute("data-hint");
+    expect(cycledHit).toBe(buriedHintText);
+
+    await page.keyboard.press(ACTION_KEY);
+
+    /* WHY: the buried target must be the one whose action fires. Since the
+       chip for the front element is inserted after the back element, the
+       buried target is the back button. */
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.body.getAttribute("data-back-clicked")),
+      )
+      .toBe("1");
+    const frontClicked = await page.evaluate(() =>
+      document.body.getAttribute("data-front-clicked"),
+    );
+    expect(frontClicked).toBeNull();
+  });
+});

--- a/test/e2e/cycle-hint.spec.ts
+++ b/test/e2e/cycle-hint.spec.ts
@@ -54,6 +54,8 @@ test.describe("cycle key on overlapping hints", () => {
     const hit = page.locator(".hint[data-state='hit']");
     await expect(hit).toHaveAttribute("data-cycle-key", CYCLE_KEY);
     await expect(hit).toHaveAttribute("data-cycle-count", "1");
+    await expect(hit).toHaveAttribute("data-cycle-total", "2");
+    await expect(hit).toHaveAttribute("data-cycle-index", /^[12]$/);
 
     /* WHY: the badge is rendered via the CSS ::before pseudo-element; the
        hit state fades it in via opacity transition (delay 200ms + 200ms
@@ -77,7 +79,7 @@ test.describe("cycle key on overlapping hints", () => {
     await expect.poll(async () => (await readBadge())?.opacity).toBe("1");
     const badge = await readBadge();
     expect(badge!.content).toContain(CYCLE_KEY);
-    expect(badge!.content).toContain("+1");
+    expect(badge!.content).toContain("/2");
 
     await page.keyboard.press(CYCLE_KEY);
 


### PR DESCRIPTION
## Summary

Implements Proposal D from #112. When the hit hint chip is overlapped by other chips (e.g. Reddit post cards where the whole card and the subreddit link share the top-left anchor), pressing the Cycle Key (default `Tab`) moves the hit through those overlapping targets so the user can select buried hints without needing to see their labels.

- New `cycleKey` setting (default `Tab`, empty disables). Wired through `content-all` keyboard handler with the matcher branch placed between the action/cancel checks and the letter check, so binding it to a hint letter or an existing action/cancel key silently loses via branch order (per spec).
- New `CycleHint` / `CycleHintInTab` message pair mirroring the existing `HitHint` path (content-all → background → content-root).
- Cycle set is snapshotted on the first press: all chips whose viewport rect intersects the hit chip's rect with positive area, DOM insertion order, includes the hit itself. Cleared on any letter input, cancel, action, or session end.
- Cycled-away previous hit chip gets `data-state=\"candidate\"`; cycled-to chip gets `data-state=\"hit\"` and `context.hitTarget` is overridden.
- Discoverability badge: `data-cycle-key` / `data-cycle-count` on the current hit chip, rendered by the user-overridable CSS via `.hint::before`. Attributes move with the current hit when cycling; count stays fixed while the snapshot is active.
- Options UI: new \"Cycle Key\" section; added to `HINTS_VS_KEYS` validation (skipped `KEY_PAIR_CONFLICTS` per spec — collisions with other keys are resolved by branch order).
- Bumped version to `4.2.0` with a new changelog entry.

## Test plan

- [x] `npm run lint && npm run test` — clean
- [x] `npm run test:e2e` — 24 tests pass, including the new `cycle-hint.spec.ts`:
  - Two overlapping targets (`docs/tests/overlapping-hints.html`), type the visible top chip's label, verify badge appears with `data-cycle-key=Tab` and `data-cycle-count=1`, press `Tab`, verify the buried chip becomes hit, press `Enter`, verify the buried target's action fired and the originally-typed target's action did not.
- [ ] Manual smoke on a Reddit timeline (out of scope for CI).