### PR TITLE
fix(hinter): broadcast hint session state to all frames

### DIFF
--- a/changelog/4.2.0.md
+++ b/changelog/4.2.0.md
@@ -1,7 +1,11 @@
 # Version 4.2.0
 
-Add Cycle Key to reach hint chips buried under overlapping chips.
+Add Cycle Key to reach buried hint chips; fix hint input dropped in iframes.
 
+- Fix hint letters being silently dropped when keyboard focus sits in a
+  frame that did not initiate the hint session (e.g. focus moves into an
+  iframe while hints are attached). The hint session state is now broadcast
+  to every frame via a new `SyncHintingState` message.
 - Add Cycle Key (default `Tab`) to cycle the hit through hint chips that
   overlap the currently-hit chip.
   - When a full label match produces a hit and other chips intersect the hit

--- a/src/background/hinter.ts
+++ b/src/background/hinter.ts
@@ -1,16 +1,26 @@
 import { Router, sendToTab } from "../lib/chrome-messages";
+import { printError } from "../lib/errors";
 import { requireTabId } from "./sender-guards";
+
+/* WHY: fire-and-forget; a sync failure must not fail the RPC the initiating
+   frame awaits. */
+function syncHintingState(tabId: number, active: boolean) {
+  sendToTab(tabId, "SyncHintingState", { active }).catch(printError);
+}
 
 export const router = Router.newRuntimeInstance()
   .add("AttachHints", async (_msg, sender) => {
-    return await sendToTab(
-      requireTabId(sender),
-      "AttachHintsInTab",
-      undefined,
-      {
+    const tabId = requireTabId(sender);
+    /* WHY: dispatch before awaiting; see SyncHintingState in chrome-messages.ts. */
+    syncHintingState(tabId, true);
+    try {
+      return await sendToTab(tabId, "AttachHintsInTab", undefined, {
         frameId: 0,
-      },
-    );
+      });
+    } catch (e) {
+      syncHintingState(tabId, false);
+      throw e;
+    }
   })
   .add("HitHint", async ({ key }, sender) => {
     return await sendToTab(
@@ -28,8 +38,10 @@ export const router = Router.newRuntimeInstance()
     });
   })
   .add("RemoveHints", async ({ options, execute }, sender) => {
+    const tabId = requireTabId(sender);
+    syncHintingState(tabId, false);
     return await sendToTab(
-      requireTabId(sender),
+      tabId,
       "RemoveHintsInTab",
       { options, execute },
       { frameId: 0 },

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -91,12 +91,7 @@ chrome.runtime.onMessage.addListener(
     .add("BlurRelay", ({ childFrameId, rect }) => {
       blurer.handleBlurRelay(childFrameId, rect);
     })
-    /* WHY: passively observe AttachHintsInTab/RemoveHintsInTab forwarded to
-       the root frame (frameId:0). Keeps the root frame's keyboard handler in
-       sync when a child frame initiated the hint session. content-root.ts
-       owns sendResponse. */
-    .addPassive("AttachHintsInTab", () => hinterClient.syncHinting(true))
-    .addPassive("RemoveHintsInTab", () => hinterClient.syncHinting(false))
+    .add("SyncHintingState", ({ active }) => hinterClient.syncHinting(active))
     .buildListener(),
 );
 

--- a/src/lib/chrome-messages.ts
+++ b/src/lib/chrome-messages.ts
@@ -85,6 +85,26 @@ export interface TabMessages {
     payload: { options: ActionOptions; execute: boolean };
     response: void;
   };
+  /**
+   * Broadcast to every frame (no frameId filter) when the background
+   * forwards AttachHints/RemoveHints, so each frame's KeyboardHandler routes
+   * keystrokes correctly even when focus sits in a frame that did not
+   * initiate the session (#120).
+   * Kept separate from AttachHintsInTab/RemoveHintsInTab on purpose: those
+   * are 1:1 RPCs to the session-owning root frame, and frames eavesdropping
+   * on them cannot observe the response, so a failed attach would strand
+   * them at hinting=true and handleKeypress would swallow every keystroke.
+   * A dedicated message lets the background compensate with {active:false}
+   * when the attach fails.
+   * INVARIANT: dispatch at request time, not after the RPC settles.
+   * AttachHintsInTab resolves only after rect streaming and RemoveHintsInTab
+   * only after the action executes; by then the next session's keystrokes
+   * can already be in flight and a late sync would clobber the newer flag.
+   */
+  SyncHintingState: {
+    payload: { active: boolean };
+    response: void;
+  };
 
   ExecuteActionInFrame: {
     payload: { id: ElementId; options: ActionOptions };
@@ -133,16 +153,6 @@ type MHandler<M, T extends keyof M> = (
   sender: chrome.runtime.MessageSender,
 ) => MResponse<M, T> | Promise<MResponse<M, T>>;
 
-/**
- * A passive handler observes a message without sending a response.
- * Use addPassive() when another listener in a different script owns the
- * sendResponse for the same message type.
- */
-type MPassiveHandler<M, T extends keyof M> = (
-  data: MPayload<M, T>,
-  sender: chrome.runtime.MessageSender,
-) => void | Promise<void>;
-
 type MSendResponseArg<M, T extends keyof M> =
   | { response: MResponse<M, T> }
   | { error: Error };
@@ -161,10 +171,6 @@ export class Router<
   RegisteredTypes extends keyof M | void,
 > {
   private readonly handlers = new Map<keyof M, MHandler<M, keyof M>>();
-  private readonly passiveHandlers = new Map<
-    keyof M,
-    MPassiveHandler<M, keyof M>
-  >();
 
   // WHY: use the static factories instead of `new Router`.
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -178,32 +184,13 @@ export class Router<
     return new Router();
   }
 
-  private isRegistered(type: keyof M): boolean {
-    return this.handlers.has(type) || this.passiveHandlers.has(type);
-  }
-
   add<T extends Exclude<keyof M, RegisteredTypes>>(
     type: T,
     handler: MHandler<M, T>,
   ): Router<M, Exclude<RegisteredTypes | T, void>> {
-    if (this.isRegistered(type))
+    if (this.handlers.has(type))
       throw Error(`Already registered: type=${String(type)}`);
     this.handlers.set(type, handler);
-    return this;
-  }
-
-  /**
-   * Register a passive handler: observes the message without sending a
-   * response. Use when another listener in a different script (e.g.
-   * content-root.ts) owns the sendResponse for this message type.
-   */
-  addPassive<T extends Exclude<keyof M, RegisteredTypes>>(
-    type: T,
-    handler: MPassiveHandler<M, T>,
-  ): Router<M, Exclude<RegisteredTypes | T, void>> {
-    if (this.isRegistered(type))
-      throw Error(`Already registered: type=${String(type)}`);
-    this.passiveHandlers.set(type, handler);
     return this;
   }
 
@@ -213,9 +200,6 @@ export class Router<
   ): Router<M, Exclude<RegisteredTypes | T, void>> {
     for (const [type, handler] of router.handlers) {
       this.handlers.set(type, handler);
-    }
-    for (const [type, handler] of router.passiveHandlers) {
-      this.passiveHandlers.set(type, handler);
     }
     return this;
   }
@@ -230,20 +214,6 @@ export class Router<
     sendResponse: (arg: MSendResponseArg<M, T>) => void,
   ): boolean | void {
     const msgType = (message as { "@type": keyof M })["@type"];
-
-    const passiveHandler = this.passiveHandlers.get(msgType);
-    if (passiveHandler) {
-      console.debug("Recieve (passive): ", message);
-      try {
-        const result = passiveHandler(message, sender);
-        if (result instanceof Promise) {
-          result.catch((e) => console.warn("Passive handler error:", e));
-        }
-      } catch (e) {
-        console.warn("Passive handler error:", e);
-      }
-      return; // WHY: do not call sendResponse; the active listener owns the response.
-    }
 
     const handler = this.handlers.get(msgType);
     if (!handler) return;

--- a/src/lib/hinter-client.ts
+++ b/src/lib/hinter-client.ts
@@ -23,9 +23,9 @@ export default class HinterClient {
   }
 
   /**
-   * WHY: keeps the root frame's keyboard handler in sync with sessions
-   * initiated by child frames. Called by content-all.ts when it observes
-   * AttachHints or RemoveHints arriving at the root frame.
+   * WHY: keyboard focus can move to a frame that did not initiate the hint
+   * session, so every frame's flag is synced via the SyncHintingState
+   * broadcast (see TabMessages in chrome-messages.ts and #120).
    */
   syncHinting(active: boolean) {
     this.hinting = active;

--- a/test/e2e/iframe-focus-sync.spec.ts
+++ b/test/e2e/iframe-focus-sync.spec.ts
@@ -1,0 +1,57 @@
+import {
+  test,
+  expect,
+  gotoTest,
+  attachHintsSticky,
+  findHintFor,
+  setSettings,
+} from "./fixtures";
+
+const STICKY_KEY = "KeyQ";
+const ACTION_KEY = "Enter";
+const CANCEL_KEY = "Escape";
+
+test.describe("hint session sync across frames", () => {
+  test.beforeEach(async ({ context }) => {
+    await setSettings(context, {
+      stickyKey: STICKY_KEY,
+      actionKey: ACTION_KEY,
+      cancelKey: CANCEL_KEY,
+    });
+  });
+
+  test.afterEach(async ({ context }) => {
+    await setSettings(context, { stickyKey: "", actionKey: "", cancelKey: "" });
+  });
+
+  test("hint letters typed while focus is in a non-initiating iframe still hit", async ({
+    page,
+  }) => {
+    await gotoTest(page, "iframe.html");
+
+    const childFrame = page.frameLocator("iframe");
+    const childInput = childFrame.locator("#child-input");
+    /* WHY: the letters below are typed inside the child frame, so its
+       keyboard handler must be set up; gotoTest only waits for the root. */
+    await expect(childFrame.locator("html")).toHaveAttribute(
+      "data-knavi-ready",
+      "1",
+    );
+
+    // WHY: the root frame holds focus here, so the root initiates the session.
+    await attachHintsSticky(page, STICKY_KEY);
+    const hintText = await findHintFor(page, "iframe");
+
+    await childInput.focus();
+    for (const ch of hintText) {
+      await page.keyboard.press(ch);
+    }
+
+    // INVARIANT: the letters must be routed to hitHint, not typed into the input.
+    const hitHint = page.locator(".hint[data-state='hit']");
+    await expect(hitHint).toHaveCount(1, { timeout: 2_000 });
+    await expect(childInput).toHaveValue("");
+
+    await page.keyboard.press(CANCEL_KEY);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #120: non-initiating frames' `HinterClient.hinting` was never synced, so hint letters typed while keyboard focus sat in a frame that did not initiate the session were silently dropped (the keydown fell through to the page element instead of routing to `hitHint`).

- Add a dedicated `SyncHintingState { active }` tab message. The background broadcasts it to every frame (no `frameId` filter) when it forwards `AttachHints` / `RemoveHints`, and compensates with `{active: false}` when the attach RPC fails.
- Replace the passive child-to-root-only observation of `AttachHintsInTab` / `RemoveHintsInTab` in `content-all` with an active `SyncHintingState` handler. `Router.addPassive` and the passive-handler machinery are removed with their only use.
- `AttachHintsInTab` / `RemoveHintsInTab` stay addressed to `{frameId: 0}`; routing/rendering remains a 1:1 RPC with the session-owning root frame.

## Design notes

The full rationale for a dedicated message (instead of broadcasting the routing RPCs to all frames) is recorded in the issue:
https://github.com/kui/knavi/issues/120#issuecomment-4981240557

One non-obvious invariant, documented on the `SyncHintingState` entry in `src/lib/chrome-messages.ts`: the sync must be dispatched at request time, not after the RPC settles. `AttachHintsInTab` resolves only after rect streaming finishes and `RemoveHintsInTab` only after the action executes; a sync sent after the `await` arrives later than the next session's keystrokes and clobbers the newer flag (this deterministically broke the "second sticky session works after an action steals focus" e2e test during development).

## Test plan

- New e2e regression test `test/e2e/iframe-focus-sync.spec.ts`: root frame initiates a sticky session, focus moves into an iframe input, typed hint letters must reach `hit` state and must not leak into the input. Verified it fails on master and passes with this change.
- `npm run lint`, `npm run test` (95 unit tests), and the full Playwright suite (25 e2e tests) all pass; the previously flaky-relevant specs (`sticky-mode`, `iframe-blur-cycle`) pass with `--repeat-each=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
