### PR TITLE
fix(hinter): reset key matchers on window blur to clear stuck cycle key

### DIFF
--- a/changelog/4.2.0.md
+++ b/changelog/4.2.0.md
@@ -1,7 +1,11 @@
 # Version 4.2.0
 
-Add Cycle Key to reach buried hint chips; fix hint input dropped in iframes.
+Add Cycle Key to reach buried hint chips; fix hint input dropped in iframes
+or after `Tab` moved focus away.
 
+- Fix hint letters being swallowed as Cycle Key presses after a `Tab` keydown
+  moved focus out of the frame (the lost keyup left `Tab` stuck in the key
+  matcher). Matcher state is now reset whenever the frame loses focus.
 - Fix hint letters being silently dropped when keyboard focus sits in a
   frame that did not initiate the hint session (e.g. focus moves into an
   iframe while hints are attached). The hint session state is now broadcast

--- a/src/content-all.ts
+++ b/src/content-all.ts
@@ -125,3 +125,6 @@ window.addEventListener(
   },
   true,
 );
+window.addEventListener("blur", () => {
+  keyboardHandler.handleBlur();
+});

--- a/src/content-all/keyboard-handler.ts
+++ b/src/content-all/keyboard-handler.ts
@@ -169,6 +169,15 @@ export class KeyboardHandlerContentAll {
   }
 
   /**
+   * WHY: a keydown that moves focus out of this frame (e.g. Tab) loses its
+   * keyup here, sticking the key in matcher history; a stuck cycle key then
+   * swallows every hint letter as a cycle match.
+   */
+  handleBlur() {
+    this.resetMatchers();
+  }
+
+  /**
    * Just hijacks the event when hinting.
    * Returns true if the event is handled.
    */

--- a/test/content-all/keyboard-handler.test.ts
+++ b/test/content-all/keyboard-handler.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+(globalThis as Record<string, unknown>).chrome = {
+  runtime: {
+    sendMessage: () => Promise.resolve({ response: undefined }),
+  },
+};
+(globalThis as Record<string, unknown>).document = { activeElement: null };
+
+const { KeyboardHandlerContentAll } =
+  await import("../../src/content-all/keyboard-handler.js");
+
+const SETTINGS = {
+  magicKey: "Space",
+  blurKey: "",
+  hints: "asdfghjkl",
+  stickyKey: "",
+  actionKey: "",
+  cancelKey: "",
+  cycleKey: "Tab",
+};
+
+function makeFakeHinter() {
+  return {
+    isHinting: false,
+    calls: [] as string[],
+    attachHints() {
+      this.isHinting = true;
+      this.calls.push("attachHints");
+      return Promise.resolve();
+    },
+    hitHint(key: string) {
+      this.calls.push(`hitHint:${key}`);
+      return Promise.resolve();
+    },
+    cycleHint() {
+      this.calls.push("cycleHint");
+      return Promise.resolve();
+    },
+    removeHints() {
+      this.isHinting = false;
+      this.calls.push("removeHints");
+      return Promise.resolve();
+    },
+  };
+}
+
+function keyEvent(type: "keydown" | "keyup", key: string, code: string) {
+  return {
+    type,
+    key,
+    code,
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  } as KeyboardEvent;
+}
+
+void describe("KeyboardHandlerContentAll", () => {
+  let hinter: ReturnType<typeof makeFakeHinter>;
+  let handler: InstanceType<typeof KeyboardHandlerContentAll>;
+
+  beforeEach(() => {
+    hinter = makeFakeHinter();
+    handler = new KeyboardHandlerContentAll(null as never, hinter as never);
+    handler.setup(SETTINGS, []);
+  });
+
+  function startHinting() {
+    assert.equal(
+      handler.handleKeydown(keyEvent("keydown", " ", "Space")),
+      true,
+    );
+    assert.equal(hinter.isHinting, true);
+  }
+
+  void test("hint letter triggers hitHint while hinting", () => {
+    startHinting();
+    assert.equal(handler.handleKeydown(keyEvent("keydown", "a", "KeyA")), true);
+    assert.deepEqual(hinter.calls, ["attachHints", "hitHint:a"]);
+  });
+
+  void test("cycle key triggers cycleHint while hinting", () => {
+    startHinting();
+    assert.equal(
+      handler.handleKeydown(keyEvent("keydown", "Tab", "Tab")),
+      true,
+    );
+    assert.deepEqual(hinter.calls, ["attachHints", "cycleHint"]);
+  });
+
+  void test("cycle key stuck by a lost keyup is cleared on blur", () => {
+    // WHY: simulates Tab moving focus out of the frame, so no keyup arrives.
+    handler.handleKeydown(keyEvent("keydown", "Tab", "Tab"));
+    handler.handleBlur();
+
+    startHinting();
+    handler.handleKeydown(keyEvent("keydown", "a", "KeyA"));
+    assert.deepEqual(hinter.calls, ["attachHints", "hitHint:a"]);
+  });
+
+  void test("without blur reset, a stuck cycle key swallows hint letters", () => {
+    handler.handleKeydown(keyEvent("keydown", "Tab", "Tab"));
+
+    startHinting();
+    handler.handleKeydown(keyEvent("keydown", "a", "KeyA"));
+    assert.deepEqual(hinter.calls, ["attachHints", "cycleHint"]);
+  });
+});


### PR DESCRIPTION
## Problem

Hints appeared but typing hint letters did nothing. Stepping through in the console showed every letter keydown matching `cycleMatcher` instead of reaching the hint-letter branch.

## Root cause

`KeyHoldMatcher.match()` checks whether the target key (`Tab` by default for the Cycle Key) is present in the held-key history. It does not check which key the current event carries. A `Tab` keydown that moves focus out of the frame never delivers its keyup to that frame, leaving `Tab` permanently stuck in `cycleMatcher`'s history. Matchers were only reset in `endSession()`, which never runs for a key stuck during normal browsing.

Since the cycle branch in `handleKeydown` precedes the hint-letter branch, a stuck `Tab` made every typed letter fire `cycleHint()` and `hitHint()` was never called.

Reproduced routes:

- `Tab` focus navigation crossing an iframe boundary or moving focus to browser UI.
- Ctrl+Tab tab switch in Vivaldi, which (unlike Chrome) delivers the `Tab` keydown to the page before switching tabs.

This is why the symptom appeared only after the Cycle Key feature landed: `Tab` is the one default-bound key whose keyup is routinely lost during everyday browsing.

## Fix

A lost keyup implies the frame lost focus, so reset all matcher histories on `window` `blur` (wired in `content-all.ts` per the entry-point rule, logic in `KeyboardHandlerContentAll.handleBlur()`). The listener uses no capture, so element-level blur events are not affected; it fires only when the frame itself loses focus.

Verified against real Chromium (driven via raw CDP, since Playwright emulates focus and masks this behavior) that `window` `blur` fires both when focus crosses frame boundaries and on tab switches.

## Notes for reviewers

- New unit tests in `test/content-all/keyboard-handler.test.ts` cover the regression (stuck `Tab` cleared by blur) and document the failure mode without the reset.
- Changelog entry added to `changelog/4.2.0.md` with the digest line updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)