### PR TITLE
docs(readme): document GitHub Actions workflow for release tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,8 @@ Edit changelog in `changelog/<CurrentVersion>.md`. It will be used for release n
 1. Check the version in [package.json](package.json)
 2. Confirm `changelog/<Version>.md`
 3. Commit and push them
-4. Execute `scripts/tag_for_release.sh`
+4. Create and push the release tag by either:
+   - Running the [tag-for-release workflow](https://github.com/kui/knavi/actions/workflows/tag-for-release.yaml)
+     on GitHub Actions ("Run workflow" button, or `gh workflow run tag-for-release.yaml`)
+   - Executing `scripts/tag_for_release.bash` locally and pushing the tag
 5. Bump minor version in [package.json](package.json) for next release


### PR DESCRIPTION
## What

Update the Release section in README.md:

- Step 4 now lists two ways to create and push the release tag: running the [tag-for-release workflow](https://github.com/kui/knavi/actions/workflows/tag-for-release.yaml) on GitHub Actions ("Run workflow" button or `gh workflow run tag-for-release.yaml`), or executing the script locally.
- Fix the stale script name: `scripts/tag_for_release.sh` was renamed to `scripts/tag_for_release.bash`.

## Why

The tag-for-release workflow added in #124 makes it possible to tag a release without a local checkout, but the README still only described the local script path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)