### PR TITLE
ci: fail tag-for-release when dispatched on a non-master ref

### DIFF
--- a/.github/workflows/tag-for-release.yaml
+++ b/.github/workflows/tag-for-release.yaml
@@ -11,6 +11,12 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
+      # WHY: workflow_dispatch cannot restrict selectable refs, so fail fast when run on a non-master ref.
+      - name: Refuse non-master ref
+        if: github.ref != 'refs/heads/master'
+        run: |
+          echo "::error::This workflow must be run on master (got $GITHUB_REF)."
+          exit 1
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - name: Install dependencies


### PR DESCRIPTION
## What

Add a guard step at the top of the `tag-for-release` workflow that fails the run with an explicit error when the selected ref is not `master`.

## Why

The "Run workflow" UI for `workflow_dispatch` always shows a ref selector, and GitHub provides no option to hide or restrict it (long-standing feature request: https://github.com/orgs/community/discussions/75933). Running the release tagging flow from any other branch would break the release process, so the workflow now fails fast instead.

A failing step was chosen over a job-level `if:` so a wrong-ref run shows up red rather than silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)